### PR TITLE
removed exceptions for gnd/vcc net for now

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
@@ -326,15 +326,15 @@ public class CellDesign extends AbstractDesign {
 			throw new DesignAssemblyException("Net with name already exists in design.");
 
 		if (net.isVCCNet()) {
-			if (vccNet != null) {
-				throw new DesignAssemblyException("VCC net already exists in design.");
-			}
+			// if (vccNet != null) {
+			// 	throw new DesignAssemblyException("VCC net already exists in design.");
+			// }
 			vccNet = net;
 		}
 		else if (net.isGNDNet()) {
-			if (gndNet != null) {
-				throw new DesignAssemblyException("GND net already exists in design.");
-			}
+			// if (gndNet != null) {
+			// 	throw new DesignAssemblyException("GND net already exists in design.");
+			// }
 			gndNet = net;
 		} 
 		


### PR DESCRIPTION
## In this commit:
- Removed the restriction that a design can only have one gnd and vcc net for now. This is to keep the functionality of the XDL packer/unpacker the same so it will continue to work.
