### PR TITLE
Replacing and hiding the old routing structures from the public API

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/explorer/TileWindow.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/explorer/TileWindow.java
@@ -39,7 +39,7 @@ import edu.byu.ece.rapidSmith.design.xdl.XdlDesign;
 import edu.byu.ece.rapidSmith.design.xdl.XdlModuleInstance;
 import edu.byu.ece.rapidSmith.design.xdl.XdlNet;
 import edu.byu.ece.rapidSmith.design.PIP;
-import edu.byu.ece.rapidSmith.design.subsite.Connection;
+import edu.byu.ece.rapidSmith.device.Connection;
 import edu.byu.ece.rapidSmith.device.Tile;
 import edu.byu.ece.rapidSmith.device.TileWire;
 import edu.byu.ece.rapidSmith.device.Wire;

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
@@ -2,6 +2,7 @@ package edu.byu.ece.rapidSmith.design.subsite;
 
 import edu.byu.ece.rapidSmith.design.PIP;
 import edu.byu.ece.rapidSmith.device.BelPin;
+import edu.byu.ece.rapidSmith.device.Connection;
 import edu.byu.ece.rapidSmith.device.SitePin;
 import edu.byu.ece.rapidSmith.device.Wire;
 

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Bel.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Bel.java
@@ -188,16 +188,20 @@ public final class Bel implements Serializable {
 	 * This method bypasses the creation of a BelPin object so it should be faster.
 	 *
 	 * @param pinName the name of the pin
-	 * @return the wire the pin of the specified name connects to or -1 if no pin
+	 * @return the wire the pin of the specified name connects to or null if no pin
 	 *   of the name exists on the BEL
 	 */
-	public int getWireOfPin(String pinName) {
+	public SiteWire getWireOfPin(String pinName) {
 		// Check both the sources and sinks structures to find the pin.
-		if (template.getSources().containsKey(pinName))
-			return template.getSources().get(pinName).getWire();
-		if (template.getSinks().containsKey(pinName))
-			return template.getSinks().get(pinName).getWire();
-		return -1;
+		if (template.getSources().containsKey(pinName)) {
+			int wireEnum = template.getSources().get(pinName).getWire();
+			return new SiteWire(this.getSite(), wireEnum);
+		}
+		if (template.getSinks().containsKey(pinName)) {
+			int wireEnum = template.getSinks().get(pinName).getWire();
+			return new SiteWire(this.getSite(), wireEnum);
+		}
+		return null;
 	}
 
 	@Override

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Connection.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Connection.java
@@ -1,13 +1,8 @@
-package edu.byu.ece.rapidSmith.design.subsite;
+package edu.byu.ece.rapidSmith.device;
 
 import edu.byu.ece.rapidSmith.design.PIP;
-import edu.byu.ece.rapidSmith.device.BelPin;
-import edu.byu.ece.rapidSmith.device.Device;
-import edu.byu.ece.rapidSmith.device.SitePin;
-import edu.byu.ece.rapidSmith.device.SiteWire;
-import edu.byu.ece.rapidSmith.device.TileWire;
-import edu.byu.ece.rapidSmith.device.Wire;
-import edu.byu.ece.rapidSmith.device.WireConnection;
+import edu.byu.ece.rapidSmith.design.subsite.DesignAssemblyException;
+import edu.byu.ece.rapidSmith.design.subsite.SitePip;
 
 import java.io.Serializable;
 import java.util.Collection;

--- a/src/main/java/edu/byu/ece/rapidSmith/device/SinkPin.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/SinkPin.java
@@ -37,7 +37,7 @@ public class SinkPin implements Serializable{
 
 	/**
 	 * Constructs a new SinkPin object.
-	 * @param switchMatrixSinkWire the wire sourcing the sink
+	 * @param switchMatrixSinkWire the enum of the wire sourcing the sink
 	 * @param xOffset the tile offset in the X direction
 	 * @param yOffset the tile offset in the Y direction
 	 */

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
@@ -344,52 +344,28 @@ public final class Site implements Serializable{
 	 * @param wire the source wire
 	 * @return the wire connections sourced by the specified wire
 	 */
-	public WireConnection[] getWireConnections(int wire) {
+	WireConnection[] getWireConnections(int wire) {
 		return getWireConnections(getTemplate(), wire);
 	}
 
-	public WireConnection[] getWireConnections(SiteType type, int wire) {
+	WireConnection[] getWireConnections(SiteType type, int wire) {
 		return getWireConnections(getTemplate(type), wire);
 	}
 
-	public WireConnection[] getWireConnections(SiteTemplate template, int wire) {
+	WireConnection[] getWireConnections(SiteTemplate template, int wire) {
 		return template.getWireConnections(wire);
 	}
 
-	public WireConnection[] getReverseConnections(int wire) {
+	WireConnection[] getReverseConnections(int wire) {
 		return getReverseConnections(getTemplate(), wire);
 	}
 
-	public WireConnection[] getReverseConnections(SiteType type, int wire) {
+	WireConnection[] getReverseConnections(SiteType type, int wire) {
 		return getReverseConnections(getTemplate(type), wire);
 	}
 
-	public WireConnection[] getReverseConnections(SiteTemplate template, int wire) {
+	WireConnection[] getReverseConnections(SiteTemplate template, int wire) {
 		return template.getReverseWireConnections(wire);
-	}
-
-	public XdlAttribute getPipAttribute(int sourceWire, int sinkWire) {
-		return getPipAttribute(getTemplate(), sourceWire, sinkWire);
-	}
-
-	public XdlAttribute getPipAttribute(SiteType type, int sourceWire, int sinkWire) {
-		return getPipAttribute(getTemplate(type), sourceWire, sinkWire);
-	}
-
-	public XdlAttribute getPipAttribute(SiteTemplate template, int sourceWire, int sinkWire) {
-		return template.getPipAttributes().get(sourceWire).get(sinkWire);
-	}
-
-	public XdlAttribute getPipAttribute(SitePip sitePip) {
-		return getPipAttribute(getTemplate(), sitePip);
-	}
-
-	public XdlAttribute getPipAttribute(SiteType type, SitePip sitePip) {
-		return getPipAttribute(getTemplate(type), sitePip);
-	}
-
-	public XdlAttribute getPipAttribute(SiteTemplate template, SitePip sitePip) {
-		return template.getPipAttribute(sitePip);
 	}
 
 	/**
@@ -560,19 +536,14 @@ public final class Site implements Serializable{
 	 * @return the pin on thes site which connects to the specified internal wire
 	 *   or null if the wire connects to no pins on this site
 	 */
-	public SitePin getSitePinOfInternalWire(int wire) {
-		return getSitePinOfInternalWire(getTemplate(), wire);
-	}
-
-	public SitePin getSitePinOfInternalWire(SiteType type, int wire) {
-		return getSitePinOfInternalWire(getTemplate(type), wire);
-	}
-
-	public SitePin getSitePinOfInternalWire(SiteTemplate template, int wire) {
-		SitePinTemplate pinTemplate = template.getInternalSiteWireMap().get(wire);
+	SitePin getSitePinOfInternalWire(int wire) {
+		SiteTemplate template = getTemplate();
+		Map<Integer, SitePinTemplate> internalSiteWireMap = template.getInternalSiteWireMap();
+		SitePinTemplate pinTemplate = internalSiteWireMap.get(wire);
 		if (pinTemplate == null)
 			return null;
-		return new SitePin(this, pinTemplate, getExternalWire(template.getType(), pinTemplate.getName()));
+		int externalWire = getExternalWire(template.getType(), pinTemplate.getName());
+		return new SitePin(this, pinTemplate, externalWire);
 	}
 
 	// Returns the wire which connects externally to the pin.  Needed to get from
@@ -586,19 +557,14 @@ public final class Site implements Serializable{
 	 * @param wire the site wire
 	 * @return the pin of the BEL in this site which connects to the specified wire
 	 */
-	public BelPin getBelPinOfWire(int wire) {
-		return getBelPinOfWire(getTemplate(), wire);
-	}
-
-	public BelPin getBelPinOfWire(SiteType type, int wire) {
-		return getBelPinOfWire(getTemplate(type), wire);
-	}
-
-	public BelPin getBelPinOfWire(SiteTemplate template, int wire) {
+	BelPin getBelPinOfWire(int wire) {
+		SiteTemplate template = getTemplate();
 		BelPinTemplate pinTemplate = template.getBelPins().get(wire);
 		if (pinTemplate == null)
 			return null;
-		Bel bel = getBel(template, pinTemplate.getId().getName());
+		String belName = pinTemplate.getId().getName();
+		Bel bel = getBel(template, belName);
+		assert bel != null : "illegal device representation";
 		return bel.getBelPin(pinTemplate.getName());
 	}
 
@@ -621,7 +587,7 @@ public final class Site implements Serializable{
 		return externalWires;
 	}
 
-	public Map<SiteType, Map<Integer, SitePinTemplate>> getExternalWireToPinNameMap() {
+	Map<SiteType, Map<Integer, SitePinTemplate>> getExternalWireToPinNameMap() {
 		return externalWireToPinNameMap;
 	}
 
@@ -659,7 +625,7 @@ public final class Site implements Serializable{
 	 * @param endWire Sink wire enum
 	 * @return True if the wires form a routethrough
 	 */
-	public boolean isRoutethrough(Integer startWire, Integer endWire) {
+	boolean isRoutethrough(Integer startWire, Integer endWire) {
 		return this.template.isRoutethrough(startWire, endWire);
 	}
 	

--- a/src/main/java/edu/byu/ece/rapidSmith/device/SiteWire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/SiteWire.java
@@ -1,8 +1,5 @@
 package edu.byu.ece.rapidSmith.device;
 
-import edu.byu.ece.rapidSmith.design.subsite.Connection;
-import edu.byu.ece.rapidSmith.device.*;
-
 import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Tile.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Tile.java
@@ -25,6 +25,7 @@ import edu.byu.ece.rapidSmith.design.PIP;
 
 import java.io.Serializable;
 import java.util.*;
+import java.util.stream.Collectors;
 
 
 /**
@@ -435,11 +436,23 @@ public class Tile implements Serializable {
 	}
 
 	/**
-	 * Gets and returns the sources of all the primitive sites in this tile.
+	 * Gets and returns the sources of all the primitive sites in this tile.  This list
+	 * is lazily created.
 	 *
 	 * @return The source wires found in this tile.
 	 */
-	public int[] getSources() {
+	public List<Wire> getSources() {
+		return Arrays.stream(sources)
+				.mapToObj(w -> new TileWire(this, w))
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Used for device creation.
+	 *
+	 * @return The source wires found in this tile.
+	 */
+	public int[] getSourcesArray() {
 		return sources;
 	}
 

--- a/src/main/java/edu/byu/ece/rapidSmith/device/TileWire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/TileWire.java
@@ -5,8 +5,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import edu.byu.ece.rapidSmith.design.subsite.Connection;
-
 /**
  * A wire inside a tile but outside a site.  This is part of the general
  * routing circuitry.  TileWires are composed of the tile the wire exists in

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Wire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Wire.java
@@ -4,8 +4,6 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import edu.byu.ece.rapidSmith.design.subsite.Connection;
-
 /**
  * Wires represent a piece of metal on a device.  Wires are composed of two
  * components, a location such as a tile or primitive site where the tile resides

--- a/src/main/java/edu/byu/ece/rapidSmith/device/browser/DeviceBrowserScene.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/browser/DeviceBrowserScene.java
@@ -36,7 +36,7 @@ import com.trolltech.qt.gui.QGraphicsSceneMouseEvent;
 import com.trolltech.qt.gui.QMenu;
 import com.trolltech.qt.gui.QPen;
 
-import edu.byu.ece.rapidSmith.design.subsite.Connection;
+import edu.byu.ece.rapidSmith.device.Connection;
 import edu.byu.ece.rapidSmith.device.*;
 import edu.byu.ece.rapidSmith.gui.NumberedHighlightedTile;
 import edu.byu.ece.rapidSmith.gui.TileScene;

--- a/src/main/java/edu/byu/ece/rapidSmith/device/creation/DeviceGenerator.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/creation/DeviceGenerator.java
@@ -768,7 +768,7 @@ public final class DeviceGenerator {
 				// Tile sources, however, are always evaluated.
 				Wire wire = new TileWire(tile, wireEnum);
 				int numSources = wireSourcesCount.get(tile).get(wireEnum);
-				if (numSources <= 1 && !arrayContains(tile.getSources(), wire.getWireEnum()))
+				if (numSources <= 1 && !arrayContains(tile.getSourcesArray(), wire.getWireEnum()))
 					continue;
 
 				addSinkWiresToTraverse(stack, wire);

--- a/src/main/java/edu/byu/ece/rapidSmith/device/creation/ExtendedDeviceInfo.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/creation/ExtendedDeviceInfo.java
@@ -3,7 +3,7 @@ package edu.byu.ece.rapidSmith.device.creation;
 import com.caucho.hessian.io.Hessian2Input;
 import com.caucho.hessian.io.Hessian2Output;
 import edu.byu.ece.rapidSmith.RSEnvironment;
-import edu.byu.ece.rapidSmith.design.subsite.Connection;
+import edu.byu.ece.rapidSmith.device.Connection;
 import edu.byu.ece.rapidSmith.device.*;
 import edu.byu.ece.rapidSmith.device.helper.HashPool;
 import edu.byu.ece.rapidSmith.device.helper.WireArray;

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/HandRouter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/HandRouter.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.Objects;
 
 import edu.byu.ece.rapidSmith.design.*;
-import edu.byu.ece.rapidSmith.design.subsite.Connection;
+import edu.byu.ece.rapidSmith.device.Connection;
 import edu.byu.ece.rapidSmith.design.subsite.RouteTree;
 import edu.byu.ece.rapidSmith.design.xdl.XdlDesign;
 import edu.byu.ece.rapidSmith.design.xdl.XdlNet;

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
@@ -25,7 +25,7 @@ import edu.byu.ece.rapidSmith.design.subsite.Cell;
 import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
 import edu.byu.ece.rapidSmith.design.subsite.CellNet;
 import edu.byu.ece.rapidSmith.design.subsite.CellPin;
-import edu.byu.ece.rapidSmith.design.subsite.Connection;
+import edu.byu.ece.rapidSmith.device.Connection;
 import edu.byu.ece.rapidSmith.design.subsite.RouteTree;
 import edu.byu.ece.rapidSmith.device.BelPin;
 import edu.byu.ece.rapidSmith.device.Bel;

--- a/src/main/java/edu/byu/ece/rapidSmith/util/DeviceDiffer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/DeviceDiffer.java
@@ -200,13 +200,13 @@ public class DeviceDiffer {
 	private void diffTilesSources(Tile gold, Tile test) {
 		Set<String> sources = new HashSet<>();
 		if (test.getSources() != null) {
-			for (Integer source : test.getSources()) {
-				sources.add(weTest.getWireName(source));
+			for (Wire source : test.getSources()) {
+				sources.add(source.getWireName());
 			}
 		}
 		if (gold.getSources() != null) {
-			for (Integer source : gold.getSources()) {
-				String sourceName = weGold.getWireName(source);
+			for (Wire source : gold.getSources()) {
+				String sourceName = source.getWireName();
 				if (!sources.remove(sourceName)) {
 					differences.add("source", sourceName, "none");
 				}

--- a/src/main/java/edu/byu/ece/rapidSmith/util/WireTraverser.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/WireTraverser.java
@@ -1,6 +1,6 @@
 package edu.byu.ece.rapidSmith.util;
 
-import edu.byu.ece.rapidSmith.design.subsite.Connection;
+import edu.byu.ece.rapidSmith.device.Connection;
 import edu.byu.ece.rapidSmith.device.Wire;
 
 import java.util.*;


### PR DESCRIPTION
Moved Connection class to the device package -- fits better nomenclaturely there.

Made package-private (where possible, some methods were needed by device generator) methods related to low level routing.

Replaced low level routing public methods with higher-level versions.

Removed the getPipAttribute methods -- they exist in the SiteTemplate and are only needed for XDL compatibility.