### PR TITLE
Fix issue #172 and #169

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/BelRoutethrough.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/BelRoutethrough.java
@@ -23,38 +23,69 @@ package edu.byu.ece.rapidSmith.design.subsite;
 import edu.byu.ece.rapidSmith.device.Bel;
 import edu.byu.ece.rapidSmith.device.BelPin;
 import edu.byu.ece.rapidSmith.device.Wire;
+import static edu.byu.ece.rapidSmith.util.Exceptions.DesignAssemblyException;
+
+import java.util.Objects;
 
 /**
- * Represents a BelRoutethrough
+ * Represents a LUT Routethrough. A LUT is used  
  *  
  * TODO: Update this to include the sink cell pin that it leads to? 
  *  
  * @author Thomas Townsend
  */
 public class BelRoutethrough {
-
-	private final Bel bel;
-	private final BelPin inputPin;
-	private final BelPin outputPin;
-	//private final CellPin sinkCellPin;
 	
-	public BelRoutethrough(Bel bel, BelPin inputPin, BelPin outputPin) {
-		this.bel = bel;
+	/**Input pin of the BelRoutethrough (A1, A2, ... , A6) */
+	private final BelPin inputPin;
+	/**Input pin of the BelRoutethrough (O5, O6) */
+	private final BelPin outputPin;
+	
+	/**
+	 * Create a new BelRoutethrough object. 
+	 * 
+	 * @param inputPin Input {@link BelPin} object (A1 - A6 pins on a LUT typically)
+	 * @param outputPin Output {@link BelPin} object (O5 or O6 pin on a LUT typically)
+	 */
+	public BelRoutethrough(BelPin inputPin, BelPin outputPin) {
+		
+		// Reject null objects
+		Objects.requireNonNull(inputPin);
+		Objects.requireNonNull(outputPin);
+		
+		// Can we assume that getBel never returns null?
+		if (inputPin.getBel().equals(outputPin.getBel())) {
+			throw new DesignAssemblyException("BelPins are not on the same Bel object!");
+		}
+		
 		this.inputPin = inputPin;
 		this.outputPin = outputPin;
 	}
 	
+	/**
+	 * Returns the {@link Bel} object of this routethrough 
+	 */
 	public Bel getBel() {
-		return this.bel;
+		return this.inputPin.getBel();
 	}
 	
+	/**
+	 * Returns the input {@link BelPin} of this routethrough
+	 */
 	public BelPin getInputPin() {
 		return this.inputPin;
 	}
 	
+	/**
+	 * Returns the output {@link BelPin} of this routethrough
+	 */
 	public BelPin getOutputPin() {
 		return this.outputPin;
 	}
+	
+	/**
+	 * Returns the {@link Wire} object connected to the output {@link BelPin} of this routethrough
+	 */
 	public Wire getOutputWire() {
 		return outputPin.getWire();
 	}

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/BelRoutethrough.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/BelRoutethrough.java
@@ -28,7 +28,8 @@ import static edu.byu.ece.rapidSmith.util.Exceptions.DesignAssemblyException;
 import java.util.Objects;
 
 /**
- * Represents a LUT Routethrough. A LUT is used  
+ * Represents a LUT Routethrough. A LUT is used as a routethrough when one of
+ * its input pins is routed directly to an output pin (i.e. O6=A4).  
  *  
  * TODO: Update this to include the sink cell pin that it leads to? 
  *  

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/BelRoutethrough.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/BelRoutethrough.java
@@ -55,7 +55,7 @@ public class BelRoutethrough {
 		Objects.requireNonNull(outputPin);
 		
 		// Can we assume that getBel never returns null?
-		if (inputPin.getBel().equals(outputPin.getBel())) {
+		if (!inputPin.getBel().equals(outputPin.getBel())) {
 			throw new DesignAssemblyException("BelPins are not on the same Bel object!");
 		}
 		

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
@@ -47,9 +47,15 @@ public class CellLibrary implements Iterable<LibraryCell> {
 		this.library = new HashMap<>();
 	}
 
-	public CellLibrary(Path filePath) throws IOException, JDOMException {
+	public CellLibrary(Path filePath) throws IOException {
 		this.library = new HashMap<>();
-		loadFromFile(filePath);
+		
+		try {
+			loadFromFile(filePath);
+		} catch (JDOMException e) {
+			// wrap the JDOMException in a generic parse exception
+			throw new Exceptions.ParseException(e);
+		}
 	}
 
 	private void loadFromFile(Path filePath) throws IOException, JDOMException {

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DeviceAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DeviceAnalyzer.java
@@ -9,12 +9,6 @@ import edu.byu.ece.rapidSmith.RSEnvironment;
 import edu.byu.ece.rapidSmith.device.Connection;
 import edu.byu.ece.rapidSmith.device.Device;
 import edu.byu.ece.rapidSmith.device.Tile;
-
-import edu.byu.ece.rapidSmith.device.TileWire;
-
-
-import java.util.HashSet;
-
 import edu.byu.ece.rapidSmith.device.Wire;
 
 public class DeviceAnalyzer {

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DotFilePrinterDemo.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DotFilePrinterDemo.java
@@ -23,7 +23,6 @@ import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
 import edu.byu.ece.rapidSmith.interfaces.vivado.TincrCheckpoint;
 import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoInterface;
 import edu.byu.ece.rapidSmith.util.DotFilePrinter;
-import org.jdom2.JDOMException;
 
 import java.io.IOException;
 
@@ -59,7 +58,7 @@ public class DotFilePrinterDemo {
 		TincrCheckpoint tcp = null;
 		try {
 			tcp = VivadoInterface.loadTCP(checkpoint);
-		} catch (JDOMException|IOException e) {
+		} catch (IOException e) {
 			System.err.println("Failed loading TCP");
 			e.printStackTrace();
 		}

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/ImportExportExample.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/ImportExportExample.java
@@ -63,7 +63,6 @@ public class ImportExportExample {
 		CellDesign design = tcp.getDesign();
 		Device device= tcp.getDevice();
 		CellLibrary libCells = tcp.getLibCells();
-		String partName = tcp.getPartName();
 		
 		// Do some manipulations, in this case just print out the design
 		System.out.println("\nPrinting out the design...");

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/placerDemo/PlacerDemo.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/placerDemo/PlacerDemo.java
@@ -30,7 +30,6 @@ import edu.byu.ece.rapidSmith.util.MessageGenerator;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
-import org.jdom2.JDOMException;
 
 import java.io.*;
 import java.nio.file.Paths;
@@ -92,13 +91,8 @@ public class PlacerDemo {
 		classSetup();
 		
 		System.out.println("Loading Design...");
-		TincrCheckpoint tcp = null;
-		try {
-			tcp = VivadoInterface.loadTCP(tcpDirectory);
-		} catch (JDOMException e) {
-			System.out.println("Error loading tcp file");
-			e.printStackTrace();
-		}
+		TincrCheckpoint tcp = VivadoInterface.loadTCP(tcpDirectory);
+		
 		CellDesign design = tcp.getDesign();
 		
 		// create a stream to vivado if in interactive mode

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
@@ -37,7 +37,6 @@ import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
 import edu.byu.ece.rapidSmith.design.subsite.CellLibrary;
 import edu.byu.ece.rapidSmith.device.Device;
 import edu.byu.ece.rapidSmith.util.Exceptions;
-import org.jdom2.JDOMException;
 
 /**
  * This class is used to interface Vivado and RapidSmith. <br>
@@ -51,7 +50,7 @@ public final class VivadoInterface {
 
 	private static final String CELL_LIBRARY_NAME = "cellLibrary.xml";
 
-	public static TincrCheckpoint loadTCP(String tcp) throws IOException, JDOMException {
+	public static TincrCheckpoint loadTCP(String tcp) throws IOException {
 		return loadTCP(tcp, false);
 	}
 	
@@ -62,7 +61,7 @@ public final class VivadoInterface {
 	 * @throws InvalidEdifNameException 
 	 * @throws EdifNameConflictException 
 	 */
-	public static TincrCheckpoint loadTCP (String tcp, boolean storeAdditionalInfo) throws IOException, JDOMException {
+	public static TincrCheckpoint loadTCP (String tcp, boolean storeAdditionalInfo) throws IOException {
 	
 		if (tcp.endsWith("/") || tcp.endsWith("\\")) {
 			tcp = tcp.substring(0, tcp.length()-1);

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
@@ -426,7 +426,7 @@ public class XdcRoutingInterface {
 			BelPin inputPin = tryGetBelPin(bel, routethroughToks[2]);
 			BelPin outputPin = tryGetBelPin(bel, routethroughToks[3]);
 		
-			belRoutethroughMap.put(bel, new BelRoutethrough(bel, inputPin, outputPin));
+			belRoutethroughMap.put(bel, new BelRoutethrough(inputPin, outputPin));
 		}
 	}
 	


### PR DESCRIPTION
In this commit:
----------------

- Updated the `BelRoutethrough` constructor to take only two pins as input (an input and output pin). The pins are now checked for null, and checked that they are on the same `Bel` object. reference issue #169. Also, added additional documentation to the `BelRoutethrough` class.

- Updated the constructor of `CellLibrary` to no longer thrown a `JDOMException`s. For users that include RapidSmith into their own project, JAR dependencies do not seem to be inherited. There may be a way to do this, but it is unclear how useful it would be. The constructor now wraps the `JDOMException `into a rapidSmith `ParseException` which is better anyway. Also, a few example programs that were catching the `JDOMException` were updated. Reference issue #172