### PR TITLE
Replaced property methods with PropertyList

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
@@ -49,8 +49,8 @@ public class CellDesign extends AbstractDesign {
 	private Map<Site, Map<Bel, Cell>> placementMap;
 	/** This is a list of all the nets in the design */
 	private Map<String, CellNet> netMap;
-	/** Map of properties of this design. */
-	private Map<Object, Property> propertyMap;
+	/** The properties of this design. */
+	private final PropertyList properties;
 	/** Map from a site to the used SitePip wires in the site*/
 	private HashMap<Site, Set<Integer>> usedSitePipsMap;
 	/** The VCC RapidSmith net */
@@ -67,6 +67,7 @@ public class CellDesign extends AbstractDesign {
 	public CellDesign() {
 		super();
 		init();
+		properties = new PropertyList();
 	}
 
 	/**
@@ -79,6 +80,7 @@ public class CellDesign extends AbstractDesign {
 	public CellDesign(String designName, String partName) {
 		super(designName, partName);
 		init();
+		properties = new PropertyList();
 	}
 
 	private void init() {
@@ -89,97 +91,14 @@ public class CellDesign extends AbstractDesign {
 	}
 
 	/**
-	 * Returns true if this cell contains a property with the specified name.
-	 *
-	 * @param propertyKey the name of the property to check for
-	 * @return true if this cell contains a property with the specified name
+	 * Returns the properties of this design in a {@link PropertyList}.  Properties
+	 * may contain metadata about a design including user-defined metadata.
+	 * @return a {@code PropertyList} containing the properties of this design
 	 */
-	public boolean hasProperty(Object propertyKey) {
-		Objects.requireNonNull(propertyKey);
-
-		return getProperty(propertyKey) != null;
+	public PropertyList getProperties() {
+		return properties;
 	}
 
-	/**
-	 * Returns the property from this cell with the specified name.
-	 *
-	 * @param propertyKey name of the property to get
-	 * @return the property with the specified name
-	 */
-	public Property getProperty(Object propertyKey) {
-		Objects.requireNonNull(propertyKey);
-
-		if (propertyMap == null)
-			return null;
-		return propertyMap.get(propertyKey);
-	}
-
-	/**
-	 * Returns the properties of this cell.  The returned collection should not be
-	 * modified by the user.
-	 *
-	 * @return the properties of this cell
-	 */
-	public Collection<Property> getProperties() {
-		if (propertyMap == null)
-			return Collections.emptyList();
-		return propertyMap.values();
-	}
-
-	/**
-	 * Updates or adds the property to this cell.
-	 *
-	 * @param property the property to add or update
-	 */
-	public void updateProperty(Property property) {
-		Objects.requireNonNull(property);
-
-		if (this.propertyMap == null)
-			this.propertyMap = new HashMap<>();
-		this.propertyMap.put(property.getKey(), property);
-	}
-	
-	/**
-	 * Updates or adds the properties in the provided collection to the properties
-	 * of this cell.
-	 *
-	 * @param properties the properties to add or update
-	 */
-	public void updateProperties(Collection<Property> properties) {
-		Objects.requireNonNull(properties);
-
-		properties.forEach(this::updateProperty);
-	}
-
-	/**
-	 * Updates the value of the property in this cell with the specified name or
-	 * creates and adds it if it is not already present.
-	 *
-	 * @param propertyKey the name of the property
-	 * @param value the value to set the property to
-	 */
-	public void updateProperty(Object propertyKey, PropertyType type, Object value) {
-		Objects.requireNonNull(propertyKey);
-		Objects.requireNonNull(type);
-		Objects.requireNonNull(value);
-
-		updateProperty(new Property(propertyKey, type, value));
-	}
-
-	/**
-	 * Removes the property with the specified name.  Returns the removed property.
-	 *
-	 * @param propertyKey the key of the property to remove
-	 * @return the removed property
-	 */
-	public Property removeProperty(Object propertyKey) {
-		Objects.requireNonNull(propertyKey);
-
-		if (propertyMap == null)
-			return null;
-		return propertyMap.remove(propertyKey);
-	}
-	
 	public boolean hasCell(String fullName) {
 		Objects.requireNonNull(fullName);
 

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
@@ -57,8 +57,8 @@ public class CellNet implements Serializable {
 	private Set<CellPin> pins;
 	/** Source pin of the net*/
 	private CellPin sourcePin;
-	/** Property map for the Net*/
-	private Map<Object, Property> propertyMap;
+	/** Properties for the Net*/
+	private final PropertyList properties;
 	/** Set of CellPins that have been marked as routed in the design*/
 	private Set<CellPin> routedSinks; 
 	/** Set to true if this net is contained within a single site's boundaries*/
@@ -89,6 +89,7 @@ public class CellNet implements Serializable {
 		this.name = name;
 		this.type = type;
 		this.isIntrasite = false;
+		this.properties = new PropertyList();
 		init();
 	}
 
@@ -134,99 +135,15 @@ public class CellNet implements Serializable {
 	void setDesign(CellDesign design) {
 		this.design = design;
 	}
-	
-	/**
-	 * Returns true if this cell contains a property with the specified name.
-	 *
-	 * @param propertyKey the name of the property to check for
-	 * @return true if this cell contains a property with the specified name
-	 */
-	public boolean hasProperty(Object propertyKey) {
-		Objects.requireNonNull(propertyKey);
-
-		return getProperty(propertyKey) != null;
-	}
 
 	/**
-	 * Returns the property from this cell with the specified name.
-	 *
-	 * @param propertyKey name of the property to get
-	 * @return the property with the specified name
+	 * Returns the properties of this net in a {@link PropertyList}.
+	 * @return a {@code PropertyList} containing the properties of this net
 	 */
-	public Property getProperty(Object propertyKey) {
-		Objects.requireNonNull(propertyKey);
-
-		if (propertyMap == null)
-			return null;
-		return propertyMap.get(propertyKey);
+	public final PropertyList getProperties() {
+		return properties;
 	}
 
-	/**
-	 * Returns the properties of this cell.  The returned collection should not be
-	 * modified by the user.
-	 *
-	 * @return the properties of this cell
-	 */
-	public Collection<Property> getProperties() {
-		if (propertyMap == null)
-			return Collections.emptyList();
-		return propertyMap.values();
-	}
-
-	/**
-	 * Updates or adds the property to this cell.
-	 *
-	 * @param property the property to add or update
-	 */
-	public void updateProperty(Property property) {
-		Objects.requireNonNull(property);
-
-		if (this.propertyMap == null)
-			this.propertyMap = new HashMap<>();
-		this.propertyMap.put(property.getKey(), property);
-	}
-
-	/**
-	 * Updates the value of the property in this cell with the specified name or
-	 * creates and adds it if it is not already present.
-	 *
-	 * @param propertyKey the name of the property
-	 * @param value the value to set the property to
-	 */
-	public void updateProperty(Object propertyKey, PropertyType type, Object value) {
-		Objects.requireNonNull(propertyKey);
-		Objects.requireNonNull(type);
-		Objects.requireNonNull(value);
-
-		updateProperty(new Property(propertyKey, type, value));
-	}
-	
-	/**
-	 * Updates or adds the properties in the provided collection to the properties
-	 * of this cell.
-	 *
-	 * @param properties the properties to add or update
-	 */
-	public void updateProperties(Collection<Property> properties) {
-		Objects.requireNonNull(properties);
-
-		properties.forEach(this::updateProperty);
-	}
-
-	/**
-	 * Removes the property with the specified name.  Returns the removed property.
-	 *
-	 * @param propertyKey hte name of the property to remove
-	 * @return the removed property
-	 */
-	public Property removeProperty(Object propertyKey) {
-		Objects.requireNonNull(propertyKey);
-
-		if (propertyMap == null)
-			return null;
-		return propertyMap.remove(propertyKey);
-	}
-	
 	/**
 	 * Returns the pins (source and sinks) of this net.  This structure should not
 	 * be modified by the user.

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/PropertyList.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/PropertyList.java
@@ -23,10 +23,7 @@ package edu.byu.ece.rapidSmith.design.subsite;
 import java.util.*;
 
 /**
- * This class represents an objects that can have properties. Any class that needs <br> 
- * to have properties, should inherit from this class. 
- * 
- * @author Thomas Townsend
+ * This class represents an objects that can have properties.
  */
 public final class PropertyList implements Iterable<Property> {
 	/** Properties of the cell */
@@ -53,10 +50,12 @@ public final class PropertyList implements Iterable<Property> {
 	}
 
 	/**
-	 * Returns the property from this cell with the specified name.
+	 * Returns the property from this cell with the specified name.  If this collection
+	 * has no property with the key {@code propertyKey}, then this method returns
+	 * {@code null}.
 	 *
 	 * @param propertyKey name of the property to get
-	 * @return the property with name <i>propertyKey</i> or null if the property
+	 * @return the property with name <i>propertyKey</i> or {@code null} if the property
 	 * is not in the cell
 	 */
 	public Property get(Object propertyKey) {
@@ -136,10 +135,12 @@ public final class PropertyList implements Iterable<Property> {
 	}
 
 	/**
-	 * Returns the value of the property with the associated name.
+	 * Returns the value of the property with the associated name.  If this collection
+	 * has no property with the key {@code propertyKey}, then this method returns
+	 * {@code null}.
 	 *
 	 * @param propertyKey the name of the property
-	 * @return the value of the specified property
+	 * @return the value of the specified property or {@code null} if it does not exist
 	 */
 	public Object getValue(Object propertyKey) {
 		Objects.requireNonNull(propertyKey);
@@ -151,22 +152,26 @@ public final class PropertyList implements Iterable<Property> {
 
 
 	/**
-	 * Return the given specified property as an integer. Only use this function <br>
-	 * if you are sure the property value can be safely cast to an int.
+	 * Return the given specified property as an integer. Only use this function
+	 * if you are sure the property value can be safely cast to an int.  If this
+	 * collection has no property with the key {@code propertyKey}, then this method
+	 * returns {@code null}.
 	 * @param propertyKey the name of the property 
-	 * @return int
+	 * @return the value as an Integer or {@code null} if it does not exist
 	 */
-	public int getIntegerValue(Object propertyKey) {
+	public Integer getIntegerValue(Object propertyKey) {
 		
 		Property property = get(propertyKey);
 		return property == null ? null : (int) property.getValue();
 	}
 	
 	/**
-	 * Return the given specified property as a string. Only use this function <br>
-	 * if you are sure the property value can be safely cast to a string.
+	 * Return the given specified property as a string. Only use this function if
+	 * you are sure the property value can be safely cast to a string.  If this
+	 * collection has no property with the key {@code propertyKey}, then this method
+	 * returns {@code null}.
 	 * @param propertyKey the name of the property 
-	 * @return string
+	 * @return the value as a String or {@code null} if it does not exist
 	 */
 	public String getStringValue(Object propertyKey) {
 			
@@ -175,22 +180,26 @@ public final class PropertyList implements Iterable<Property> {
 	}
 	
 	/**
-	 * Return the given specified property as a boolean. Only use this function <br>
-	 * if you are sure the property value can be safely cast to a boolean.
+	 * Return the given specified property as a boolean. Only use this function if
+	 * you are sure the property value can be safely cast to a boolean.  If this
+	 * collection has no property with the key {@code propertyKey}, then this method
+	 * returns {@code null}.
 	 * @param propertyKey the name of the property 
-	 * @return boolean
+	 * @return the value as a Boolean or {@code null} if it does not exist
 	 */
-	public boolean getBooleanValue(Object propertyKey) {
+	public Boolean getBooleanValue(Object propertyKey) {
 		
 		Property property = get(propertyKey);
 		return property == null ? null : (boolean) property.getValue();
 	}
 	
 	/**
-	 * Return the given specified property as a double. Only use this function <br>
-	 * if you are sure the property value can be safely cast to a double.
+	 * Return the given specified property as a double. Only use this function if
+	 * you are sure the property value can be safely cast to a double.  If this
+	 * collection has no property with the key {@code propertyKey}, then this method
+	 * returns {@code null}.
 	 * @param propertyKey the name of the property 
-	 * @return double 
+	 * @return the value as a Double or {@code null} if it does not exist
 	 */
 	public double getDoubleValue(Object propertyKey) {
 		

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/PropertyList.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/PropertyList.java
@@ -20,10 +20,7 @@
 
 package edu.byu.ece.rapidSmith.design.subsite;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * This class represents an objects that can have properties. Any class that needs <br> 
@@ -31,21 +28,28 @@ import java.util.Objects;
  * 
  * @author Thomas Townsend
  */
-public class PropertyList {
-	
+public final class PropertyList implements Iterable<Property> {
 	/** Properties of the cell */
 	private Map<Object, Property> properties = null;
-		
+
+	private void initPropertiesMap() {
+		properties = new HashMap<>(4);
+	}
+
+	public int size() {
+		return properties == null ? 0 : properties.size();
+	}
+
 	/**
 	 * Returns true if this cell contains a property with the specified name.
 	 *
 	 * @param propertyKey the name of the property to check for
 	 * @return true if this cell contains a property with the specified name
 	 */
-	public final boolean hasProperty(Object propertyKey) {
+	public final boolean has(Object propertyKey) {
 		Objects.requireNonNull(propertyKey);
 
-		return getProperty(propertyKey) != null;
+		return get(propertyKey) != null;
 	}
 
 	/**
@@ -55,7 +59,7 @@ public class PropertyList {
 	 * @return the property with name <i>propertyKey</i> or null if the property
 	 * is not in the cell
 	 */
-	public Property getProperty(Object propertyKey) {
+	public Property get(Object propertyKey) {
 		Objects.requireNonNull(propertyKey);
 
 		if (properties == null)
@@ -64,28 +68,15 @@ public class PropertyList {
 	}
 
 	/**
-	 * Returns the properties of this cell.  The returned collection should not be
-	 * modified by the user.
-	 *
-	 * @return the properties of this cell
-	 */
-	public Collection<Property> getProperties() {
-		if (properties == null) {
-			properties = new HashMap<>();
-		}
-		return properties.values();
-	}
-
-	/**
 	 * Updates or adds the properties in the provided collection to the properties
 	 * of this cell.
 	 *
 	 * @param properties the properties to add or update
 	 */
-	public void updateProperties(Collection<Property> properties) {
+	public void updateAll(Collection<Property> properties) {
 		Objects.requireNonNull(properties);
 
-		properties.forEach(this::updateProperty);
+		properties.forEach(this::update);
 	}
 
 	/**
@@ -93,11 +84,11 @@ public class PropertyList {
 	 *
 	 * @param property the property to add or update
 	 */
-	public void updateProperty(Property property) {
+	public void update(Property property) {
 		Objects.requireNonNull(property);
 
 		if (this.properties == null)
-			this.properties = new HashMap<>();
+			initPropertiesMap();
 		this.properties.put(property.getKey(), property);
 	}
 
@@ -109,12 +100,12 @@ public class PropertyList {
 	 * @param type the new type of the property
 	 * @param value the value to set the property to
 	 */
-	public void updateProperty(Object propertyKey, PropertyType type, Object value) {
+	public void update(Object propertyKey, PropertyType type, Object value) {
 		Objects.requireNonNull(propertyKey);
 		Objects.requireNonNull(type);
 		Objects.requireNonNull(value);
 
-		updateProperty(new Property(propertyKey, type, value));
+		update(new Property(propertyKey, type, value));
 	}
 
 	/**
@@ -123,7 +114,7 @@ public class PropertyList {
 	 * @param propertyKey the name of the property to remove
 	 * @return the removed property. null if the property doesn't exist
 	 */
-	public Property removeProperty(Object propertyKey) {
+	public Property remove(Object propertyKey) {
 		Objects.requireNonNull(propertyKey);
 
 		if (properties == null)
@@ -138,10 +129,10 @@ public class PropertyList {
 	 * @param value the value to compare the property's to test
 	 * @return true if the value matches the property's value
 	 */
-	public boolean testPropertyValue(Object propertyKey, Object value) {
+	public boolean testValue(Object propertyKey, Object value) {
 		Objects.requireNonNull(propertyKey);
 
-		return Objects.equals(getPropertyValue(propertyKey), value);
+		return Objects.equals(getValue(propertyKey), value);
 	}
 
 	/**
@@ -150,22 +141,24 @@ public class PropertyList {
 	 * @param propertyKey the name of the property
 	 * @return the value of the specified property
 	 */
-	public Object getPropertyValue(Object propertyKey) {
+	public Object getValue(Object propertyKey) {
 		Objects.requireNonNull(propertyKey);
 
-		Property property = getProperty(propertyKey);
+		Property property = get(propertyKey);
 		return property == null ? null : property.getValue();
 	}
-	
+
+
+
 	/**
 	 * Return the given specified property as an integer. Only use this function <br>
 	 * if you are sure the property value can be safely cast to an int.
 	 * @param propertyKey the name of the property 
 	 * @return int
 	 */
-	public int getIntegerPropertyValue(Object propertyKey) {
+	public int getIntegerValue(Object propertyKey) {
 		
-		Property property = getProperty(propertyKey);
+		Property property = get(propertyKey);
 		return property == null ? null : (int) property.getValue();
 	}
 	
@@ -175,9 +168,9 @@ public class PropertyList {
 	 * @param propertyKey the name of the property 
 	 * @return string
 	 */
-	public String getStringPropertyValue(Object propertyKey) {
+	public String getStringValue(Object propertyKey) {
 			
-		Property property = getProperty(propertyKey);
+		Property property = get(propertyKey);
 		return property == null ? null : (String) property.getValue();
 	}
 	
@@ -187,9 +180,9 @@ public class PropertyList {
 	 * @param propertyKey the name of the property 
 	 * @return boolean
 	 */
-	public boolean getBooleanPropertyValue(Object propertyKey) {
+	public boolean getBooleanValue(Object propertyKey) {
 		
-		Property property = getProperty(propertyKey);
+		Property property = get(propertyKey);
 		return property == null ? null : (boolean) property.getValue();
 	}
 	
@@ -199,9 +192,14 @@ public class PropertyList {
 	 * @param propertyKey the name of the property 
 	 * @return double 
 	 */
-	public double getDoublePropertyValue(Object propertyKey) {
+	public double getDoubleValue(Object propertyKey) {
 		
-		Property property = getProperty(propertyKey);
+		Property property = get(propertyKey);
 		return property == null ? null : (double) property.getValue();
+	}
+
+	@Override
+	public Iterator<Property> iterator() {
+		return properties.values().iterator();
 	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/device/PortDirection.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/PortDirection.java
@@ -46,25 +46,25 @@ public enum PortDirection {
 	public static PortDirection getPortDirection(Cell portCell) {
 		
 		checkIsValidPort(portCell);
-		return (PortDirection)portCell.getProperty("Dir").getValue();
+		return (PortDirection)portCell.getProperties().get("Dir").getValue();
 	}
 	
 	public static boolean isInputPort(Cell portCell) {
 		
 		checkIsValidPort(portCell);
-		return portCell.getProperty("Dir").getValue() == PortDirection.IN;
+		return portCell.getProperties().get("Dir").getValue() == PortDirection.IN;
 	}
 	
 	public static boolean isOutputPort(Cell portCell) {
 
 		checkIsValidPort(portCell);
-		return portCell.getProperty("Dir").getValue() == PortDirection.OUT;
+		return portCell.getProperties().get("Dir").getValue() == PortDirection.OUT;
 	}
 	
 	public static boolean isInoutPort(Cell portCell) {
 
 		checkIsValidPort(portCell);
-		return portCell.getProperty("Dir").getValue() == PortDirection.INOUT;
+		return portCell.getProperties().get("Dir").getValue() == PortDirection.INOUT;
 	}
 	
 	private static void checkIsValidPort(Cell portCell) {

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/CreateDesignExample.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/CreateDesignExample.java
@@ -64,12 +64,12 @@ public class CreateDesignExample {
 		// Create a new cell and add it to the current design.  It is a LUT1 cell.
 		Cell invcell = design.addCell(new Cell("lutcell", libCells.get("LUT1")));
 		// Set the INIT property for the LUT cell (program the LUT) 
-		invcell.updateProperty("INIT", PropertyType.DESIGN, "2'h1");
+		invcell.getProperties().update("INIT", PropertyType.DESIGN, "2'h1");
 
 		// Create a flip flop cell and set its properties 
 		Cell ffcell = design.addCell(new Cell("ffcell", libCells.get("FDRE")));   
-		ffcell.updateProperty("INIT", PropertyType.DESIGN, "INIT0");
-		ffcell.updateProperty("SR", PropertyType.DESIGN, "SRLOW");
+		ffcell.getProperties().update("INIT", PropertyType.DESIGN, "INIT0");
+		ffcell.getProperties().update("SR", PropertyType.DESIGN, "SRLOW");
 		
 		// Create IOB's for the circuit's q output and for its clk input
 		Cell qbufcell = design.addCell(new Cell("qbuf", libCells.get("OBUF")));

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
@@ -102,7 +102,7 @@ public final class EdifInterface {
 		// create RS2 cell design
 		String partName = ((StringTypedValue)top.getTopDesign().getProperty("part").getValue()).getStringValue();
 		CellDesign design= new CellDesign(top.getTopDesign().getName(), partName);	
-		design.updateProperties(createCellProperties(topLevelCell.getPropertyList()));
+		design.getProperties().updateAll(createCellProperties(topLevelCell.getPropertyList()));
 		
 		// add all the cells and nets to the design
 		processTopLevelEdifPorts(design, topLevelCell.getInterface(), libCells);
@@ -146,7 +146,7 @@ public final class EdifInterface {
 									String.format("%s[%d]", portSuffix, reverseBusIndex(port.getWidth(), busMember.bitPosition())) :
 									portSuffix;
 				Cell portCell = new Cell(portName, libCell);
-				portCell.updateProperty(new Property("Dir", PropertyType.USER, PortDirection.getPortDirectionForImport(portCell)));
+				portCell.getProperties().update(new Property("Dir", PropertyType.USER, PortDirection.getPortDirectionForImport(portCell)));
 				design.addCell(portCell);
 			}
 		}
@@ -173,7 +173,7 @@ public final class EdifInterface {
 			
 			// Add properties to the cell 
 			// TODO: when macros are added, we will need to update this
-			newcell.updateProperties(createCellProperties(eci.getPropertyList()));
+			newcell.getProperties().updateAll(createCellProperties(eci.getPropertyList()));
 		}
 	}
 	
@@ -217,7 +217,7 @@ public final class EdifInterface {
 				design.addNet(cn);
 			}
 			
-			cn.updateProperties(createCellProperties(net.getPropertyList()));
+			cn.getProperties().updateAll(createCellProperties(net.getPropertyList()));
 		}
 	}
 	
@@ -595,7 +595,7 @@ public final class EdifInterface {
 	/*
 	 * Converts a collection of RapidSmith properties to an EDIF property list
 	 */
-	private static PropertyList createEdifPropertyList (Collection<Property> properties) {
+	private static PropertyList createEdifPropertyList (edu.byu.ece.rapidSmith.design.subsite.PropertyList properties) {
 		PropertyList edifProperties = new PropertyList();
 		
 		for (Property prop : properties) {

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/LutRoutethroughInserter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/LutRoutethroughInserter.java
@@ -181,7 +181,7 @@ public class LutRoutethroughInserter {
 		// TODO: replace this code with a function
 		//create a new lut1 cell with the appropriate init string
 		Cell buffer = new Cell(ROUTETHROUGH_NAME + routethroughID, libCells.get("LUT1") );
-		buffer.updateProperty(new Property("INIT", PropertyType.EDIF, ROUTETHROUGH_INIT_STRING));
+		buffer.getProperties().update(new Property("INIT", PropertyType.EDIF, ROUTETHROUGH_INIT_STRING));
 		design.addCell(buffer);
 		
 		// break the netlist 

--- a/src/main/java/edu/byu/ece/rapidSmith/util/DotFilePrinter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/DotFilePrinter.java
@@ -255,7 +255,7 @@ public class DotFilePrinter {
 		}
 		
 		// add cell info .. TODO: update this to print all properties of a cell
-		String lutString = (c.getLibCell().isLut() ? "\\n" + c.getProperty("INIT").getValue() : "");
+		String lutString = (c.getLibCell().isLut() ? "\\n" + c.getProperties().getValue("INIT") : "");
 		builder.append(String.format(" { <%d>%s%s\\n%s\\n(%s) } ", cellId, getAbbreviatedCellName(c), lutString, c.getBel().getName(), c.getLibCell().getName()));
 		
 		// add output pin info

--- a/src/test/java/ImportTest.java
+++ b/src/test/java/ImportTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import edu.byu.ece.rapidSmith.design.subsite.*;
 import edu.byu.ece.rapidSmith.device.families.FamilyInfo;
 import edu.byu.ece.rapidSmith.device.families.FamilyInfos;
 import org.jdom2.JDOMException;
@@ -47,12 +48,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import edu.byu.ece.rapidSmith.RSEnvironment;
-import edu.byu.ece.rapidSmith.design.subsite.BelRoutethrough;
-import edu.byu.ece.rapidSmith.design.subsite.Cell;
-import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
-import edu.byu.ece.rapidSmith.design.subsite.CellNet;
-import edu.byu.ece.rapidSmith.design.subsite.CellPin;
-import edu.byu.ece.rapidSmith.design.subsite.RouteTree;
 import edu.byu.ece.rapidSmith.device.Bel;
 import edu.byu.ece.rapidSmith.device.BelPin;
 import edu.byu.ece.rapidSmith.device.Device;
@@ -648,8 +643,8 @@ public abstract class ImportTest {
 			// For cells with non-default properties, make sure the value in RapidSmith, matches the value in Vivado
 			// TODO: filter out non-EDIF properties?
 			String propertyList = "";
-			for (Object propertyName : cell.getPropertyNames()) {
-				propertyList += propertyName + " ";
+			for (Property property : cell.getProperties()) {
+				propertyList += property.getStringKey() + " ";
 			}
 			
 			String command = String.format("tincr::report_property_values %s {%s}", cell.getName(), propertyList);
@@ -659,7 +654,7 @@ public abstract class ImportTest {
 			
 			for (String tclProperty : result) {
 				String[] tclPropertyToks = tclProperty.split("!");
-				String rsPropertyValue = cell.getProperty(tclPropertyToks[0]).getValue().toString();
+				String rsPropertyValue = cell.getProperties().getValue(tclPropertyToks[0]).toString();
 				String tclPropertyValue = tclPropertyToks[1];
 				
 				boolean propertiesMatch = true;


### PR DESCRIPTION
Replaced property methods and fields in Cell, CellDesign and CellNet with PropertyList

Renamed methods in PropertyList to not include word Property (makes them much shorter to use)
Made PropertyList implement Collection.
Removed getProperties method -- this class is iterable now