### PR TITLE
faster Travis-CI builds, fixes #199

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: java
 jdk:
   - oraclejdk8
-install:
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+install: echo "skip './gradlew assemble' step"
 script: ./gradlew build --continue

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
 jdk:
   - oraclejdk8
+install:
+script: ./gradlew build --continue


### PR DESCRIPTION
This pull request speeds up Travis-CI builds by 36%. This is accomplished by caching maven and kotlin dependencies between builds, and by combing the gradlew build process into one step.