### PR TITLE
LutRoutethroughInserter fix

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/LutRoutethroughInserter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/LutRoutethroughInserter.java
@@ -45,9 +45,6 @@ import edu.byu.ece.rapidSmith.device.BelPin;
  * needs to be inserted on the bel to achieve the same functionality. 
  *  
  * TODO: add option to create a deep copy of the 
- * 
- * @author Thomas Townsend
- *
  */
 public class LutRoutethroughInserter {
 	
@@ -126,6 +123,7 @@ public class LutRoutethroughInserter {
 				BelPin rtSource = tryFindRoutethroughSourcePin(routeTree, sinks);
 						
 				if (rtSource != null) { // we found a routethrough
+					assert(!sinks.isEmpty());
 					insertRouteThroughBel(net, rtSource, sinks);
 				}
 			}
@@ -161,7 +159,11 @@ public class LutRoutethroughInserter {
 			}
 			else if (current.isLeaf()) {
 				BelPin bp = current.getConnectingBelPin();
-				sinks.add(belPinToCellPinMap.get(bp));
+				
+				// add all sinks that are not connected to LUTs
+				if (!bp.getBel().getName().endsWith("LUT")) {
+					sinks.add(belPinToCellPinMap.get(bp));
+				}
 			}
 		}
 		

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
@@ -324,7 +324,7 @@ public class XdcPlacementInterface {
 	private Stream<Cell> sortCellsForXdcExport(CellDesign design) {
 		
 		// cell bins
-		ArrayList<Cell> sorted = new ArrayList<>(design.getCells().size());
+		ArrayList<Cell> sorted = new ArrayList<>(design.getCells().size());		
 		ArrayList<Cell> lutCellsD = new ArrayList<>();
 		ArrayList<Cell> lutCellsABC = new ArrayList<>();
 		ArrayList<Cell> carryCells = new ArrayList<>();
@@ -333,7 +333,7 @@ public class XdcPlacementInterface {
 		
 		// traverse the cells and drop them in the correct bin
 		Iterator<Cell> cellIt = design.getLeafCells().iterator();
-		//for (Cell cell : design.getCells) {
+		
 		while (cellIt.hasNext()) {
 			Cell cell = cellIt.next();
 			
@@ -347,7 +347,6 @@ public class XdcPlacementInterface {
 			
 			if (belName.endsWith("LUT")) {
 				if (belName.contains("D")) {
-					//System.out.println(cell.getName());
 					lutCellsD.add(cell);
 				}
 				else {
@@ -369,7 +368,6 @@ public class XdcPlacementInterface {
 		}
 				
 		// append all other cells in the correct order
-		
 		return Stream.of(sorted.stream(), 
 				lutCellsD.stream(), 
 				lutCellsABC.stream(), 
@@ -377,14 +375,5 @@ public class XdcPlacementInterface {
 				carryCells.stream(), 
 				ff5Cells.stream())
 				.flatMap(Function.identity());
-		
-		/*
-		sorted.addAll(lutCells);
-		sorted.addAll(ffCells);
-		sorted.addAll(carryCells);		
-		sorted.addAll(ff5Cells);
-		*/
-	
-		//return sorted;
 	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/util/DotFilePrinter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/DotFilePrinter.java
@@ -225,6 +225,18 @@ public class DotFilePrinter {
 		return dotBuilder.toString();
 	}
 	
+
+	/**
+	 * Creates a DOT string of the specified {@link RouteTree} object.
+	 * The resulting DOT graph is given a default name of "RouteTree"
+	 * 
+	 * @param tree {@link RouteTree} to print
+	 * @return A DOT string
+	 */
+	public static String getRouteTreeDotString(RouteTree route) {
+		return getRouteTreeDotString(route, "RouteTree");
+	}
+	
 	/**
 	 * Creates a DOT string of the intersite route of the specified {@link CellNet}.
 	 * This function assumes that a RouteTree has been assigned to the net.
@@ -232,19 +244,28 @@ public class DotFilePrinter {
 	 * @param net {@link CellNet}
 	 */
 	public static String getRouteTreeDotString(CellNet net) {
-		
+		return getRouteTreeDotString(net.getIntersiteRouteTree(), net.getName());
+	}
+	
+	/**
+	 * Creates a DOT string of the specified {@link RouteTree} object.
+	 * 
+	 * @param tree {@link RouteTree} to print
+	 * @param name Name of the generated DOT graph.
+	 * @return A DOT string
+	 */
+	public static String getRouteTreeDotString(RouteTree route, String name) {
 		// initialize function
 		Queue<RouteTree> rtQueue = new LinkedList<RouteTree>();
 		Map<RouteTree, Integer> nodeIds = new HashMap<>(); 
 		StringBuilder builder = new StringBuilder();
-		RouteTree route = net.getIntersiteRouteTree();
 		
 		if(route == null) {
 			throw new Exceptions.DesignAssemblyException("Net needs to have a RouteTree to generate dot string");
 		}
 		
 		// append the header
-		builder.append("digraph \"" + net.getName() + "\"{\n");
+		builder.append("digraph \"" + name + "\"{\n");
 				
 		// create the unique ID list for RouteTrees
 		route.iterator().forEachRemaining(rt -> nodeIds.put(rt, nodeIds.size()));
@@ -273,7 +294,7 @@ public class DotFilePrinter {
 		builder.append("}");
 		return builder.toString();
 	}
-	
+		
 	private boolean isCellPinInSite(CellPin pin, Site site) { 
 		return pin != null && pin.getCell().getSite().equals(site);
 	}

--- a/src/test/java/design/assembly/MacroTests.java
+++ b/src/test/java/design/assembly/MacroTests.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2016 Brigham Young University
+ *
+ * This file is part of the BYU RapidSmith Tools.
+ *
+ * BYU RapidSmith Tools is free software: you may redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * BYU RapidSmith Tools is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GNU General Public License is included with the BYU
+ * RapidSmith Tools. It can be found at doc/LICENSE.GPL3.TXT. You may
+ * also get a copy of the license at <http://www.gnu.org/licenses/>.
+ */
 package design.assembly;
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/java/design/assembly/MacroTests.java
+++ b/src/test/java/design/assembly/MacroTests.java
@@ -1,4 +1,4 @@
-package DesignAssembly;
+package design.assembly;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -23,7 +23,6 @@ import edu.byu.ece.rapidSmith.design.subsite.CellLibrary;
 import edu.byu.ece.rapidSmith.design.subsite.CellNet;
 import edu.byu.ece.rapidSmith.design.subsite.CellPin;
 import edu.byu.ece.rapidSmith.design.subsite.CellPinType;
-import edu.byu.ece.rapidSmith.util.Exceptions;
 
 /**
  *	Tests macro cell functionality in RapidSmith

--- a/src/test/java/design/tcpExport/RoutethroughInserterTest.java
+++ b/src/test/java/design/tcpExport/RoutethroughInserterTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2016 Brigham Young University
+ *
+ * This file is part of the BYU RapidSmith Tools.
+ *
+ * BYU RapidSmith Tools is free software: you may redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * BYU RapidSmith Tools is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GNU General Public License is included with the BYU
+ * RapidSmith Tools. It can be found at doc/LICENSE.GPL3.TXT. You may
+ * also get a copy of the license at <http://www.gnu.org/licenses/>.
+ */
 package design.tcpExport;
 
 import org.junit.jupiter.api.BeforeAll;

--- a/src/test/java/design/tcpExport/RoutethroughInserterTest.java
+++ b/src/test/java/design/tcpExport/RoutethroughInserterTest.java
@@ -1,0 +1,165 @@
+package design.tcpExport;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import edu.byu.ece.rapidSmith.RSEnvironment;
+import edu.byu.ece.rapidSmith.design.NetType;
+import edu.byu.ece.rapidSmith.design.subsite.Cell;
+import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
+import edu.byu.ece.rapidSmith.design.subsite.CellLibrary;
+import edu.byu.ece.rapidSmith.design.subsite.CellNet;
+import edu.byu.ece.rapidSmith.design.subsite.RouteTree;
+import edu.byu.ece.rapidSmith.device.BelPin;
+import edu.byu.ece.rapidSmith.device.Connection;
+import edu.byu.ece.rapidSmith.device.Device;
+import edu.byu.ece.rapidSmith.device.Site;
+import edu.byu.ece.rapidSmith.device.Wire;
+import edu.byu.ece.rapidSmith.interfaces.vivado.LutRoutethroughInserter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+
+/**
+ * Tests the {@link LutRoutethroughInserter} to verify that LUT routethroughs
+ * are correctly created on design export. 
+ */
+@RunWith(JUnitPlatform.class)
+public class RoutethroughInserterTest {
+	
+	// Objects needed for the test 
+	private static Device device;
+	private static CellLibrary libCells;
+	
+	/**
+	 * Initializes the test by loading a {@link Device} and 
+	 * {@link CellLibrary} into memory.
+	 */
+	@BeforeAll
+	public static void initializeTest() {
+		try {
+			device = RSEnvironment.defaultEnv().getDevice("xc7a100tcsg324");
+			libCells = new CellLibrary(RSEnvironment.defaultEnv()
+													.getPartFolderPath("xc7a100tcsg324")
+													.resolve("cellLibrary.xml"));
+		} catch (IOException e) {
+			fail("Cannot find cell library XML in test directory. Setup is incorrect.");
+		}
+	}
+	
+	/**
+	 * Creates a simple netlist, and wires ones of the nets using a routethrough {@link Connection}
+	 * in the device. The {@link LutRoutethroughInserter} is run to verify that the routethrough
+	 * {@link Connection} is replaced with a passthrough LUT1.
+	 */
+	@Test
+	@DisplayName("LUT Routethrough Insert Test")
+	public void routeThroughInsertTest() throws IOException {
+		// Create the test design
+		CellDesign testDesign = createTestDesign();
+		assertNull(testDesign.getCell("rapidSmithRoutethrough0"), 
+				"Routethrough should not be added to design until after inserter is run");
+		assertNull(testDesign.getNet("rapidSmithRoutethroughNet0"), 
+				"Routethrough should not be added to design until after inserter is run");
+		
+		// Run the inserter 
+		LutRoutethroughInserter inserter = new LutRoutethroughInserter(testDesign, libCells);
+		inserter.execute();
+				
+		// Check that a RT LUT is added to the design and initialized correctly
+		Cell rtCell = testDesign.getCell("rapidSmithRoutethrough0");
+		assertNotNull(rtCell, "Routethrough cell not added to design.");
+		assertEquals(libCells.get("LUT1"), rtCell.getLibCell(), "Routethrough cell is not the correct type.");
+		assertEquals("2'h2", rtCell.getProperties().get("INIT").getStringValue(), "Routethrough INIT equation is incorrect.");
+		
+		// Check that a RT net is added to the design and connects the output of the RT LUT to the sink cell pin
+		CellNet rtNet = testDesign.getNet("rapidSmithRoutethroughNet0");
+		assertNotNull(rtNet, "Routethrough net not added to design.");
+		assertEquals(2, rtNet.getPins().size(), "Routethrough net connects to the incorrect number of pins");
+		assertTrue(rtNet.isConnectedToPin(rtCell.getPin("O")), "Routethrough net should connect to the output pin of the routhrough LUT");
+		assertTrue(rtNet.isConnectedToPin(testDesign.getCell("carry").getPin("DI[0]")), 
+				"RoutethroughInserterTest net should connect to carry4/DI[0]");
+			
+		// Test that net that used the routethrough connection was disconnected 
+		// from the sink cell pin and reconnected to the RT LUT input.
+		CellNet in1 = testDesign.getNet("in1");
+		assertEquals(2, in1.getPins().size(), "Net \"in1\" should still connect to two pins after the inserter is run");
+		assertTrue(in1.isConnectedToPin(rtCell.getPin("I0")), "Net \"in1\" should be connected to pin I0 of the routethrough LUT");
+		assertFalse(in1.isConnectedToPin(testDesign.getCell("carry").getPin("DI[0]")), 
+				"Net \"in1\" should no longer be connected to pin DI[0] of the routethrough LUT");
+	}
+	
+	/*
+	 * Creates a small design that can be used to test the RoutethroughInserter 
+	 */
+	private CellDesign createTestDesign() {
+		CellDesign design = new CellDesign("TestDesign", device.getPartName());
+
+		// create partial netlist
+		Cell lut1 = design.addCell(new Cell("lut1", libCells.get("LUT1")));
+		Cell carry = design.addCell(new Cell("carry", libCells.get("CARRY4"))); 
+		Cell iport1 = design.addCell(new Cell("iport1", libCells.get("IPORT")));
+		Cell iport2 = design.addCell(new Cell("iport2", libCells.get("IPORT")));
+		
+		CellNet in1 = design.addNet(new CellNet("in1", NetType.WIRE));
+		in1.connectToPins(Arrays.asList(iport1.getPin("PAD"), carry.getPin("DI[0]")));
+		
+		CellNet in2 = design.addNet(new CellNet("in2", NetType.WIRE));
+		in2.connectToPins(Arrays.asList(iport2.getPin("PAD"), lut1.getPin("I0")));
+		
+		CellNet lutout = design.addNet(new CellNet("lutout", NetType.WIRE));
+		lutout.connectToPins(Arrays.asList(lut1.getPin("O"), carry.getPin("S[0]")));
+		
+		// place LUT and carry cells on the same site
+		Site site = device.getSite("SLICE_X4Y82");
+		
+		design.placeCell(lut1, site.getBel("A6LUT"));
+		lut1.getPin("I0").mapToBelPin(site.getBel("A6LUT").getBelPin("A3"));
+		
+		design.placeCell(carry, site.getBel("CARRY4"));
+		carry.getPin("DI[0]").mapToBelPin(site.getBel("CARRY4").getBelPin("DI0"));
+		carry.getPin("S[0]").mapToBelPin(site.getBel("CARRY4").getBelPin("S0"));
+		
+		// create a RouteTree object that uses a routethrough
+		RouteTree route = routeInternalNet(site.getSinkPin("A3").getInternalWire(), site.getBel("CARRY4").getBelPin("DI0"));
+		in1.addSinkRouteTree(site.getSinkPin("A3"), route);
+		
+		return design;
+	}
+	
+	/*
+	 * Creates a RouteTree data structure that should use a routethrough connection
+	 * (this is easier than hand creating the RouteTree).
+	 */
+	private RouteTree routeInternalNet(Wire startWire, BelPin sink) {
+		
+		RouteTree start = new RouteTree(startWire);
+		Queue<RouteTree> rtQueue = new LinkedList<RouteTree>();
+		
+		rtQueue.add(start);
+		
+		while (!rtQueue.isEmpty()) {
+			RouteTree tree = rtQueue.poll();
+			
+			BelPin terminal = tree.getConnectingBelPin();
+			if (terminal != null && sink.equals(terminal)) {
+				start.prune(tree);
+				break;
+			}
+			
+			// add all of the connections to the queue
+			for (Connection conn : tree.getWire().getWireConnections()) {
+				rtQueue.add(tree.addConnection(conn));
+			}
+		}
+		
+		return start;
+	}
+}

--- a/src/test/java/design/tcpImport/DesignVerificationTest.java
+++ b/src/test/java/design/tcpImport/DesignVerificationTest.java
@@ -1,4 +1,4 @@
-package DesignImport;
+package design.tcpImport;
 /*
  * Copyright (c) 2016 Brigham Young University
  *

--- a/src/test/java/design/tcpImport/DesignVerificationTests.java
+++ b/src/test/java/design/tcpImport/DesignVerificationTests.java
@@ -1,4 +1,4 @@
-package DesignImport;
+package design.tcpImport;
 /*
  * Copyright (c) 2016 Brigham Young University
  *

--- a/src/test/java/design/tcpImport/ImportTest.java
+++ b/src/test/java/design/tcpImport/ImportTest.java
@@ -1,4 +1,4 @@
-package DesignImport;
+package design.tcpImport;
 import java.io.IOException;
 import java.nio.file.Path;
 


### PR DESCRIPTION
This pull request adds a fix for a bug in the `LutRoutethroughInserter`. If a routethrough used the same pin as another LUT cell, the netlist would be modified incorrectly. The picture below shows an example case: 

![image](https://cloud.githubusercontent.com/assets/7906642/23099401/f4e8948c-f622-11e6-8ced-5b52c5281994.png)

In this image, the A5LUT cell is being used as a routethrough with the A2 pin. However, the LUT cell "Yo[3]_i_6__5" also uses the A2 pin. This no longer causes problems with the `LutRoutethroughInserter` (was tested by importing and exported a fully routed CORDIC design).

Other changes in this pull request include:

- A unit test was added to verify that the `LutRoutethroughInserter `now works as expected.

- The test package hierarchy was refactored to be more clean

- A few other miscellaneous changes (mostly code cleanup)