### PR TITLE
Design Overview Refactor

### DIFF
--- a/src/test/java/design/assembly/OverviewTest.java
+++ b/src/test/java/design/assembly/OverviewTest.java
@@ -18,7 +18,7 @@
  * also get a copy of the license at <http://www.gnu.org/licenses/>.
  */
 
-package DesignAssembly;
+package design.assembly;
 import java.io.IOException;
 import java.lang.Integer;
 import java.util.Arrays;
@@ -46,7 +46,7 @@ import edu.byu.ece.rapidSmith.design.NetType;
  * @author Mark Crossen
  */
 @RunWith(JUnitPlatform.class)
-public class DesignTest {
+public class OverviewTest {
 
     private static CellLibrary libCells;
     private static Device device;


### PR DESCRIPTION
When I refactored the design overview test, I refactored it into the DesignAssembly package without realizing that the packages were renamed out from under me. This pull request fixes my mistake.