### PR TITLE
Pretty Printer - Macro Support

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
@@ -200,7 +200,7 @@ public class DesignAnalyzer {
 			
 			// Print if it is an internal net
 			if (n.isInternal())
-				System.out.println("Internal Net");
+				System.out.println("  Internal Net");
 
 			// Print the net's pins
 			// Source pin first
@@ -237,9 +237,9 @@ public class DesignAnalyzer {
 				assert(n.getIntersiteRouteTreeList().size() <= 1);
 				String s = createRoutingString(n, n.getSourceRouteTree(), true, true);
 				if (Objects.equals(s, ""))
-					System.out.println("<<<Unrouted>>>");
+					System.out.println("  <<<Unrouted>>>");
 				else
-					System.out.println("Physical routing: { " + createRoutingString(n, n.getSourceRouteTree(), true, true) + " }"); 
+					System.out.println("  Physical routing: { " + createRoutingString(n, n.getSourceRouteTree(), true, true) + " }"); 
 			}
 		}
 	}		

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
@@ -88,6 +88,33 @@ public class DesignAnalyzer {
 		}
 	}
 	
+	/**
+	 * Helper function for prettyPrintDesign(). 
+	 * Print out a formatted representation of a macro cell's internal cell.
+	 * @param c The internal cell to be pretty printed.
+	 */
+	private static void prettyPrintInternalCell(Cell c)
+	{
+		System.out.println("    " + c.getName() + " " + 
+				c.getLibCell().getName());
+		if (c.isPlaced())
+			// Print out its placement
+			System.out.println("      <<<Placed on: " + c.getBel() + ">>>");
+		else System.out.println("      <<<Unplaced>>>");
+		
+		// Print out the external pins
+		for (CellPin cp : c.getPins()) {
+			System.out.println("      Pin: " + cp.getName() + " " + 
+					cp.getDirection() + " " + 
+					(cp.getNet()!=null?cp.getNet().getName():"<unconnected>"));
+		}
+		// Print the properties for a given cell if there are any
+		// For now, properties are strings. 
+		for (Property p : c.getProperties()) {
+			String s = "      Property: " + p.toString();
+			System.out.println(s);
+		}		
+	}
 	
 	/**
 	 * Print out a formatted representation of a design to help visualize it.  Another way of visualizing designs is illustrated
@@ -96,30 +123,84 @@ public class DesignAnalyzer {
 	 */
 	public static void prettyPrintDesign(CellDesign design) {
 		// Print the cells
+		
 		for (Cell c : design.getCells()) {
 			System.out.println("\nCell: " + c.getName() + " " + 
 					c.getLibCell().getName());
-			if (c.isPlaced())
-				// Print out its placement
-				System.out.println("  <<<Placed on: " + c.getBel() + ">>>");
-			else System.out.println("  <<<Unplaced>>>");
-			// Print out the pins
-			for (CellPin cp : c.getPins()) {
-				System.out.println("  Pin: " + cp.getName() + " " + 
-						cp.getDirection() + " " + 
-						(cp.getNet()!=null?cp.getNet().getName():"<unconnected>"));
+			// Print macro cell info
+			if (c.isMacro())
+			{
+				System.out.println("  Macro (Parent) Cell");
+				
+				// Print out the pins
+				for (CellPin cp : c.getPins()) {
+					System.out.println("  Pin: " + cp.getName() + " " + 
+							cp.getDirection() + " " + 
+							(cp.getNet()!=null?cp.getNet().getName():"<unconnected>"));
+				}
+				// Print the properties for a given cell if there are any
+				// For now, properties are strings. 
+				for (Property p : c.getProperties()) {
+					String s = "  Property: " + p.toString();
+					System.out.println(s);
+				}		
+				
+				// Print out the names of the internal cells
+				Collection<Cell> internalCells = c.getInternalCells();
+				
+				if (internalCells != null && !internalCells.isEmpty())
+				{
+					System.out.println("  Internal Cells:");
+					for (Iterator<Cell> it = internalCells.iterator(); it.hasNext(); )
+					{
+						Cell internalCell = it.next();
+						prettyPrintInternalCell(internalCell);
+					}
+				}
+						
+				// Print out names of internal nets
+				Collection<CellNet> internalNets = c.getInternalNets();
+	
+				if (internalNets != null && !internalNets.isEmpty())
+				{
+					System.out.println("  Internal Nets:");
+					for (Iterator<CellNet> it = internalNets.iterator(); it.hasNext(); )
+					{
+						CellNet internalNet = it.next();
+						System.out.println("    " + internalNet.getName());
+					}
+				}
 			}
-			// Print the properties for a given cell if there are any
-			// For now, properties are strings. 
-			for (Property p : c.getProperties()) {
-				String s = "  Property: " + p.toString();
-				System.out.println(s);
+			else
+			{
+				// Leaf Cell
+				if (c.isPlaced())
+					// Print out its placement
+					System.out.println("  <<<Placed on: " + c.getBel() + ">>>");
+				else System.out.println("  <<<Unplaced>>>");
+				
+				// Print out the external pins
+				for (CellPin cp : c.getPins()) {
+					System.out.println("  Pin: " + cp.getName() + " " + 
+							cp.getDirection() + " " + 
+							(cp.getNet()!=null?cp.getNet().getName():"<unconnected>"));
+				}
+				// Print the properties for a given cell if there are any
+				// For now, properties are strings. 
+				for (Property p : c.getProperties()) {
+					String s = "  Property: " + p.toString();
+					System.out.println(s);
+				}		
 			}
 		}
 		
 		// Print the nets
 		for (CellNet n : design.getNets()) {
 			System.out.println("\nNet: " + n.getName());
+			
+			// Print if it is an internal net
+			if (n.isInternal())
+				System.out.println("Internal Net");
 
 			// Print the net's pins
 			// Source pin first

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
@@ -89,108 +89,40 @@ public class DesignAnalyzer {
 	}
 	
 	/**
-	 * Helper function for prettyPrintDesign(). 
-	 * Print out a formatted representation of a macro cell's internal cell.
-	 * @param c The internal cell to be pretty printed.
-	 */
-	private static void prettyPrintInternalCell(Cell c)
-	{
-		System.out.println("    " + c.getName() + " " + 
-				c.getLibCell().getName());
-		if (c.isPlaced())
-			// Print out its placement
-			System.out.println("      <<<Placed on: " + c.getBel() + ">>>");
-		else System.out.println("      <<<Unplaced>>>");
-		
-		// Print out the external pins
-		for (CellPin cp : c.getPins()) {
-			System.out.println("      Pin: " + cp.getName() + " " + 
-					cp.getDirection() + " " + 
-					(cp.getNet()!=null?cp.getNet().getName():"<unconnected>"));
-		}
-		// Print the properties for a given cell if there are any
-		// For now, properties are strings. 
-		for (Property p : c.getProperties()) {
-			String s = "      Property: " + p.toString();
-			System.out.println(s);
-		}		
-	}
-	
-	/**
 	 * Print out a formatted representation of a design to help visualize it.  Another way of visualizing designs is illustrated
 	 * in the DotFilePrinterDemo program in the examples2 directory.  
 	 * @param design The design to be pretty printed.
 	 */
 	public static void prettyPrintDesign(CellDesign design) {
 		// Print the cells
-		
 		for (Cell c : design.getCells()) {
-			System.out.println("\nCell: " + c.getName() + " " + 
-					c.getLibCell().getName());
-			// Print macro cell info
+			prettyPrintCell(c);
+
 			if (c.isMacro())
-			{
-				System.out.println("  Macro (Parent) Cell");
-				
-				// Print out the pins
-				for (CellPin cp : c.getPins()) {
-					System.out.println("  Pin: " + cp.getName() + " " + 
-							cp.getDirection() + " " + 
-							(cp.getNet()!=null?cp.getNet().getName():"<unconnected>"));
-				}
-				// Print the properties for a given cell if there are any
-				// For now, properties are strings. 
-				for (Property p : c.getProperties()) {
-					String s = "  Property: " + p.toString();
-					System.out.println(s);
-				}		
-				
-				// Print out the names of the internal cells
-				Collection<Cell> internalCells = c.getInternalCells();
-				
-				if (internalCells != null && !internalCells.isEmpty())
-				{
-					System.out.println("  Internal Cells:");
-					for (Iterator<Cell> it = internalCells.iterator(); it.hasNext(); )
-					{
-						Cell internalCell = it.next();
-						prettyPrintInternalCell(internalCell);
-					}
-				}
-						
+			{						
 				// Print out names of internal nets
 				Collection<CellNet> internalNets = c.getInternalNets();
 	
 				if (internalNets != null && !internalNets.isEmpty())
 				{
-					System.out.println("  Internal Nets:");
 					for (Iterator<CellNet> it = internalNets.iterator(); it.hasNext(); )
 					{
 						CellNet internalNet = it.next();
-						System.out.println("    " + internalNet.getName());
+						System.out.println("  Internal Net: " + internalNet.getName());
 					}
 				}
-			}
-			else
-			{
-				// Leaf Cell
-				if (c.isPlaced())
-					// Print out its placement
-					System.out.println("  <<<Placed on: " + c.getBel() + ">>>");
-				else System.out.println("  <<<Unplaced>>>");
 				
-				// Print out the external pins
-				for (CellPin cp : c.getPins()) {
-					System.out.println("  Pin: " + cp.getName() + " " + 
-							cp.getDirection() + " " + 
-							(cp.getNet()!=null?cp.getNet().getName():"<unconnected>"));
+				// Print out the internal cells
+				Collection<Cell> internalCells = c.getInternalCells();
+				
+				if (internalCells != null && !internalCells.isEmpty())
+				{
+					for (Iterator<Cell> it = internalCells.iterator(); it.hasNext(); )
+					{
+						Cell internalCell = it.next();
+						prettyPrintCell(internalCell);
+					}
 				}
-				// Print the properties for a given cell if there are any
-				// For now, properties are strings. 
-				for (Property p : c.getProperties()) {
-					String s = "  Property: " + p.toString();
-					System.out.println(s);
-				}		
 			}
 		}
 		
@@ -200,7 +132,7 @@ public class DesignAnalyzer {
 			
 			// Print if it is an internal net
 			if (n.isInternal())
-				System.out.println("  Internal Net");
+				System.out.println("  *Internal Net*");
 
 			// Print the net's pins
 			// Source pin first
@@ -332,6 +264,37 @@ public class DesignAnalyzer {
 				numrouted++;
 		System.out.println("The design has: " + design.getNets().size() + " nets, "  + numrouted + " of them are routed.");
 		
+	}
+	
+	/**
+	 * Print out a formatted representation of a cell. Placement is not printed for macro cells.
+	 * @param c The internal cell to be pretty printed.
+	 */
+	public static void prettyPrintCell(Cell c)
+	{
+		System.out.println("\nCell: " + c.getName() + " " + 
+					c.getLibCell().getName());
+		
+		if (c.isMacro()) System.out.println("  *Macro (Parent) Cell*");
+		else {
+			if (c.isPlaced())
+				// Print out its placement
+				System.out.println("  <<<Placed on: " + c.getBel() + ">>>");
+			else System.out.println("  <<<Unplaced>>>");
+		}
+
+		// Print out the external pins
+		for (CellPin cp : c.getPins()) {
+			System.out.println("  Pin: " + cp.getName() + " " + 
+					cp.getDirection() + " " + 
+					(cp.getNet()!=null?cp.getNet().getName():"<unconnected>"));
+		}
+		// Print the properties for a given cell if there are any
+		// For now, properties are strings. 
+		for (Property p : c.getProperties()) {
+			String s = "  Property: " + p.toString();
+			System.out.println(s);
+		}		
 	}
 	
 }


### PR DESCRIPTION
This pull request adds support for macro cells in the pretty printer in DesignAnalyzer. 

Specifically...

When cells are being printed:
- When a cell is detected as a macro cell, "Macro (Parent) Cell" is printed. 
- Its pins and properties are then printed.
- The internal cells are then printed, along with their pins and properties
- The names of any internal nets are printed last.

When nets are being printed:
- If the net is an internal cell, "Internal Net" is first printed.

