### PR TITLE
Consistent checkpoint arguments for DesignAnalyzer and ImportExportExample

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
@@ -52,7 +52,7 @@ public class DesignAnalyzer {
 		
 		// Load a TINCR checkpoint
 		System.out.println("Loading Design...");
-		VivadoCheckpoint vcp = VivadoInterface.loadRSCP(args[0] + ".rscp");
+		VivadoCheckpoint vcp = VivadoInterface.loadRSCP(args[0]);
 		CellDesign design = vcp.getDesign();
 		
 		// Print out a representation of the design 
@@ -60,7 +60,7 @@ public class DesignAnalyzer {
 		
 		System.out.println();
 		
-		// Print out some summary statistics onthe design
+		// Print out some summary statistics on the design
 		summarizeDesign(design);      
 		
 		printCellBelMappings(design);

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/ImportExportExample.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/ImportExportExample.java
@@ -46,7 +46,7 @@ public class ImportExportExample {
 		}
 		
 		String checkpointIn = args[0];
-		String checkpointOut = args[0] + ".tcp";
+		String checkpointOut = checkpointIn.substring(0, checkpointIn.length() - 4) + "tcp";
 
 		System.out.println("Starting ImportExportExample...\n");
 


### PR DESCRIPTION
This pull requests very slightly changes the DesignAnalyzer and ImportExportExample example programs. DesignAnalyzer expected to be passed in a .rscp checkpoint without the .rscp, like "add". ImportExportExample on the other hand, expected "add.rscp". ImportExportExample would also then export .tcp's with names like "add.rscp.tcp".

This pull request makes the two example programs consistent, so they both expect the full filename of the .rscp checkpoint. ImportExportExample will also save .tcp checkpoints with only ".tcp" and not ".rscp.tcp".