### PR TITLE
Mostly optimizations and handy methods

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
@@ -64,6 +64,8 @@ public class CellDesign extends AbstractDesign {
 	private List<XdcConstraint> vivadoConstraints;
 	/** For design imported from Vivado, this fields contains how Vivado implemented the design (regular or out-of-context)*/
 	private ImplementationMode mode;
+	/** Map of used PIPs to their Input Values in a Site **/
+	private Map<Site, Map<String, String>> pipInValues;
 	
 	/**
 	 * Constructor which initializes all member data structures. Sets name and
@@ -95,6 +97,7 @@ public class CellDesign extends AbstractDesign {
 		netMap = new HashMap<>();
 		usedSitePipsMap = new HashMap<>();
 		mode = ImplementationMode.REGULAR;
+		pipInValues = new HashMap<>();
 	}
 
 	/**
@@ -716,7 +719,7 @@ public class CellDesign extends AbstractDesign {
 	public void setUsedSitePipsAtSite(Site ps, Set<Integer> usedWires) {
 		this.usedSitePipsMap.put(ps, usedWires);
 	}
-
+	
 	/**
 	 * Returns the used wires (as enumerations), of the specified {@link Site}
 	 * 
@@ -724,6 +727,31 @@ public class CellDesign extends AbstractDesign {
 	 */
 	public  Set<Integer> getUsedSitePipsAtSite(Site ps) {
 		return this.usedSitePipsMap.getOrDefault(ps, Collections.emptySet());
+	}
+	
+	/**
+	 * Add a mapping of used PIPs to their input route in a site. 
+	 * @param ps {@link Site} to route
+	 * @param pipInVals Map of used PIPs to its input wire
+	 */
+	public void addPIPInputValsAtSite(Site ps, Map<String, String> pipInVals){
+		this.pipInValues.put(ps, pipInVals);
+	}
+	
+	/**
+	 * Returns a mapping of used PIPs to their input route
+	 * @param ps {@link Site} object
+	 */
+	public Map<String, String> getPIPInputValsAtSite(Site ps){
+		return this.pipInValues.getOrDefault(ps, null);
+	}
+	
+	public void setPipInValues(Map<Site, Map<String, String>> newVals){
+		this.pipInValues = newVals;
+	}
+	
+	public Map<Site, Map<String, String>> getPipInValues(){
+		return this.pipInValues;
 	}
 
 	/**

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
@@ -719,7 +719,7 @@ public class CellDesign extends AbstractDesign {
 	public void setUsedSitePipsAtSite(Site ps, Set<Integer> usedWires) {
 		this.usedSitePipsMap.put(ps, usedWires);
 	}
-	
+
 	/**
 	 * Returns the used wires (as enumerations), of the specified {@link Site}
 	 * 

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
@@ -79,10 +79,6 @@ public class CellNet implements Serializable {
 	/** Maps a connecting SitePin of the net, to the RouteTree connected to the SitePin*/
 	private Map<SitePin, RouteTree> sitePinToRTMap;
 	
-	//speed up isClkNet call
-	private boolean isClkNet;
-	private boolean clkNetStatusSet = false;
-	
 	//speed up source pin call
 	private boolean isMultiSourcedNet;
 	private boolean multiSourceStatusSet = false;
@@ -106,8 +102,6 @@ public class CellNet implements Serializable {
 	private void init() {
 		this.pins = new HashSet<>();
 		this.isInternal = false;
-		this.isClkNet = false;
-		this.clkNetStatusSet = false;
 		this.isMultiSourcedNet = false;
 		this.multiSourceStatusSet = false;
 		sourcePins = new HashSet<CellPin>();
@@ -233,13 +227,10 @@ public class CellNet implements Serializable {
 	 */
 	public List<CellPin> getAllSourcePins() {
 		return sourcePins.stream().collect(Collectors.toList());
-		//return getPins().stream()
-		//		.filter(CellPin::isOutpin)
-		//		.collect(Collectors.toList());
 	}
 
 	/**
-	 * Checks if this net contains multiple source pins.  This can be true only
+	 * Checks if this net contains multiple source pins. This can be true only
 	 * if it contains inout pins.
 	 *
 	 * @return true if this net contains multiple source pins.
@@ -426,20 +417,13 @@ public class CellNet implements Serializable {
 	 * @return {@code true} if this net is a clock net
 	 */
 	public boolean isClkNet() {
-		
-		if(this.clkNetStatusSet){
-			return this.isClkNet;
-		}
-		
 		for (CellPin p : this.pins) {
 			if (p.getType() == CellPinType.CLOCK) {
-				this.isClkNet = true;
+				return true;
 			}
 		}
 		
-		this.clkNetStatusSet = true;
-		
-		return this.isClkNet;
+		return false;
 	}
 	
 	/**

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
@@ -490,11 +490,11 @@ public class CellNet implements Serializable {
 	public boolean isStaticNet() {
 		return type == NetType.VCC || type == NetType.GND;
 	}
-	
+
 	/* **********************************
 	 * 	    Physical Route Functions
 	 * **********************************/
-	
+
 	/**
 	 * Adds a {@link SitePin} source to the net. <b>NOTE</b>: Only two site pins can be marked
 	 * as sources for a net. An exception will be thrown if you try to add more.
@@ -526,6 +526,9 @@ public class CellNet implements Serializable {
 		return this.sourceSitePinList == null ? false : this.sourceSitePinList.remove(sitePin); 
 	}
 	
+	/**
+	 * Removes all source site pins from the net. 
+	 */
 	public void removeAllSourceSitePins(){
 		this.sourceSitePinList = null;
 	}

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPin.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPin.java
@@ -189,16 +189,22 @@ public abstract class CellPin implements Serializable {
 			belPinMappingSet = new HashSet<>();
 		}
 		
-		//User added code
-		if(this.getNet() != null){
-			if(this.getNet().getAllSourcePins().size() == 1){ //if this is the only source pin
-				if(this.getNet().getSourcePin().equals(this)){ //if this is the net's source pin
-					//remap the SitePin
-					if(this.getNet().getSourceSitePin() != null){ //if there existed source site pin
-						if(!this.getCell().getSite().equals(this.getNet().getSourceSitePin().getSite())){ //and the site has changed (e.g. this cell is on a new site)
-							SitePin toAdd = this.getCell().getSite().getSitePin(this.getNet().getSourceSitePin().getName());
-							this.getNet().removeAllSourceSitePins(); //set to "same" site pin on the new site
-							this.getNet().addSourceSitePin(toAdd);
+		// Workaround to make the source site pin update when unplacing and unrouting a design:
+		CellNet net = this.getNet();
+		if(net != null){
+			// If this is the only source pin
+			if(net.getAllSourcePins().size() == 1){ 
+				// If this is the net's source pin
+				if(net.getSourcePin().equals(this)){ 
+					// If there existed source site pin
+					SitePin sourceSitePin = net.getSourceSitePin();
+					if(sourceSitePin != null){ 
+						// And if the site has changed (e.g. this cell is on a new site)
+						if(!this.getCell().getSite().equals(sourceSitePin.getSite())){
+							// Remap the source SitePin
+							SitePin toAdd = this.getCell().getSite().getSitePin(sourceSitePin.getName());
+							net.removeAllSourceSitePins(); // Set to "same" site pin on the new site
+							net.addSourceSitePin(toAdd);
 						}
 					}
 				}

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPin.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPin.java
@@ -31,6 +31,7 @@ import edu.byu.ece.rapidSmith.device.Bel;
 import edu.byu.ece.rapidSmith.device.BelId;
 import edu.byu.ece.rapidSmith.device.BelPin;
 import edu.byu.ece.rapidSmith.device.PinDirection;
+import edu.byu.ece.rapidSmith.device.SitePin;
 import edu.byu.ece.rapidSmith.util.Exceptions;
 
 /**
@@ -186,6 +187,22 @@ public abstract class CellPin implements Serializable {
 		
 		if (belPinMappingSet == null) {
 			belPinMappingSet = new HashSet<>();
+		}
+		
+		//User added code
+		if(this.getNet() != null){
+			if(this.getNet().getAllSourcePins().size() == 1){ //if this is the only source pin
+				if(this.getNet().getSourcePin().equals(this)){ //if this is the net's source pin
+					//remap the SitePin
+					if(this.getNet().getSourceSitePin() != null){ //if there existed source site pin
+						if(!this.getCell().getSite().equals(this.getNet().getSourceSitePin().getSite())){ //and the site has changed (e.g. this cell is on a new site)
+							SitePin toAdd = this.getCell().getSite().getSitePin(this.getNet().getSourceSitePin().getName());
+							this.getNet().removeAllSourceSitePins(); //set to "same" site pin on the new site
+							this.getNet().addSourceSitePin(toAdd);
+						}
+					}
+				}
+			}
 		}
 		
 		return belPinMappingSet.add(pin);

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
@@ -69,6 +69,9 @@ public final class RouteTree implements
 
 	@Deprecated
 	public void setCost(int cost) {
+		if(cost < 0){
+			cost = Integer.MAX_VALUE;
+		}
 		this.cost = cost;
 	}
 
@@ -285,5 +288,15 @@ public final class RouteTree implements
 	@Override
 	public int hashCode() {
 		return Objects.hash(wire);
+	}
+	
+	public String toRouteString(){
+		StringBuilder toReturn = new StringBuilder();
+		toReturn.append(this.getWire().getFullWireName()+"\n");
+		int iterationNum = 0;
+		for(RouteTree sink : this.getSinkTrees()){
+			toReturn.append(sink.toRouteString());
+		}
+		return toReturn.toString();
 	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
@@ -280,8 +280,6 @@ public final class RouteTree implements
 		}
 	}
 
-	// Uses identity equals
-
 	/**
 	 * Hash is based on the wire of this node.
 	 */

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
@@ -293,7 +293,6 @@ public final class RouteTree implements
 	public String toRouteString(){
 		StringBuilder toReturn = new StringBuilder();
 		toReturn.append(this.getWire().getFullWireName()+"\n");
-		int iterationNum = 0;
 		for(RouteTree sink : this.getSinkTrees()){
 			toReturn.append(sink.toRouteString());
 		}

--- a/src/main/java/edu/byu/ece/rapidSmith/device/PIP.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/PIP.java
@@ -106,6 +106,20 @@ public final class PIP implements Serializable {
 				(endWire.equals(other.startWire) && startWire.equals(other.endWire));
 	}
 
+	public String getName() {
+		StringBuilder name = new StringBuilder();
+		name.append(startWire.getTile().getName()+"/"+startWire.getTile().getType().getName()+".");
+		name.append(startWire.getWireName());
+		if(startWire.getTile().getType().getName().contains("CLB")){
+			name.append("->");
+		}
+		else{
+			name.append("->>");
+		}
+		name.append(endWire.getWireName());
+		return name.toString();
+	}
+	
 	/**
 	 * Creates a string representation of this PIP using the WireEnumerator
 	 * class.

--- a/src/main/java/edu/byu/ece/rapidSmith/device/SiteWire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/SiteWire.java
@@ -92,6 +92,10 @@ public class SiteWire implements Wire, Serializable {
 				.map(wc -> new SiteWireConnection(this, wc))
 				.collect(Collectors.toList());
 	}
+	
+	public WireConnection[] getWireConnectionsArray() {
+		return site.getWireConnections(siteType, wire);
+	}
 
 	@Override
 	public Collection<Connection> getPinConnections() {
@@ -141,6 +145,10 @@ public class SiteWire implements Wire, Serializable {
 		return Arrays.stream(wireConnections)
 				.map(wc -> new ReverseSiteWireConnection(this, wc))
 				.collect(Collectors.toList());
+	}
+	
+	public WireConnection[] getReverseWireConnectionsArray() {
+		return site.getReverseConnections(siteType, wire);
 	}
 
 	@Override

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Tile.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Tile.java
@@ -516,7 +516,8 @@ public class Tile implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(name);
+		return column*1000+row;
+		//return Objects.hash(name);
 	}
 
 	@Override

--- a/src/main/java/edu/byu/ece/rapidSmith/device/TileType.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/TileType.java
@@ -80,6 +80,10 @@ public final class TileType implements Comparable<TileType>, Serializable {
 	public String toString() {
 		return family.name() + "." + name;
 	}
+	
+	public String getName() {
+		return name;
+	}
 
 	/**
 	 * Returns the constant of this type with the specified name. The string must match

--- a/src/main/java/edu/byu/ece/rapidSmith/device/TileType.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/TileType.java
@@ -81,6 +81,10 @@ public final class TileType implements Comparable<TileType>, Serializable {
 		return family.name() + "." + name;
 	}
 	
+	/**
+	 * Returns the name of the tile type.
+	 * @return the name of the tile type.
+	 */
 	public String getName() {
 		return name;
 	}

--- a/src/main/java/edu/byu/ece/rapidSmith/device/TileWire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/TileWire.java
@@ -93,6 +93,10 @@ public class TileWire implements Wire, Serializable {
 				.map(wc -> new TileWireConnection(this, wc))
 				.collect(Collectors.toList());
 	}
+	
+	public WireConnection[] getWireConnectionsArray(){
+		return tile.getWireConnections(wire);
+	}
 
 	@Override
 	public Collection<SitePin> getAllConnectedPins() {
@@ -155,6 +159,10 @@ public class TileWire implements Wire, Serializable {
 		return Arrays.stream(wireConnections)
 				.map(wc -> new ReverseTileWireConnection(this, wc))
 				.collect(Collectors.toList());
+	}
+	
+	public WireConnection[] getReverseWireConnectionsArray() {
+		return tile.getReverseConnections(wire);
 	}
 
 	@Override

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Wire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Wire.java
@@ -40,6 +40,8 @@ public interface Wire extends Serializable {
 	 * Return connection linking this wire to other wires in the same hierarchy.
 	 */
 	Collection<Connection> getWireConnections();
+	
+	WireConnection[] getWireConnectionsArray();
 
 	/**
 	 * Returns connection linking this wire to another wire in a different
@@ -76,6 +78,8 @@ public interface Wire extends Serializable {
 	 * Returns connection linking this wire to its drivers in the same hierarchy.
 	 */
 	Collection<Connection> getReverseWireConnections();
+	
+	WireConnection[] getReverseWireConnectionsArray();
 
 	/**
 	 * Returns the connected site pins for each possible type of the connected site.

--- a/src/main/java/edu/byu/ece/rapidSmith/device/creation/XDLRCParserListener.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/creation/XDLRCParserListener.java
@@ -27,7 +27,6 @@ import java.util.List;
  *  XDLRC parse element, the parser will call the associated listener method of
  *  each registered listener.
  */
-@SuppressWarnings("UnusedParameters")
 public abstract class XDLRCParserListener {
 	protected void enterXdlResourceReport(List<String> tokens) { }
 	protected void exitXdlResourceReport(List<String> tokens) { }

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
@@ -32,7 +32,6 @@ import edu.byu.ece.rapidSmith.design.subsite.CellPin;
 import edu.byu.ece.rapidSmith.design.subsite.Property;
 import edu.byu.ece.rapidSmith.design.subsite.RouteTree;
 import edu.byu.ece.rapidSmith.device.BelPin;
-import edu.byu.ece.rapidSmith.device.PIP;
 import edu.byu.ece.rapidSmith.device.BelId;
 import edu.byu.ece.rapidSmith.device.SitePin;
 import org.jdom2.JDOMException;

--- a/src/main/java/edu/byu/ece/rapidSmith/gui/TileScene.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/gui/TileScene.java
@@ -131,7 +131,6 @@ public class TileScene extends QGraphicsScene{
 	 * @param hideTiles hide the tiles?
 	 * @param drawSites draw the primtives?
 	 */
-	@SuppressWarnings("unchecked")
 	public void initializeScene(boolean hideTiles, boolean drawSites){
 		this.clear();
 		prevX = 0;

--- a/src/main/java/edu/byu/ece/rapidSmith/gui/WidgetMaker.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/gui/WidgetMaker.java
@@ -37,7 +37,6 @@ public class WidgetMaker {
 		treeWidget.setHeaderLabel(header);
 		
 		HashMap<FamilyType, QTreeWidgetItem> familyItems = new HashMap<>();
-		HashMap<String, QTreeWidgetItem> subFamilyItems = new HashMap<>();
 
 		RSEnvironment env = RSEnvironment.defaultEnv();
 		for(String partName : env.getAvailableParts()){

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
@@ -589,6 +589,9 @@ public class XdcRoutingInterface {
 		HashSet<Integer> usedSitePips = new HashSet<>();
 		
 		String namePrefix = "intrasite:" + site.getType().name() + "/";
+
+		//create hashmap that shows pip used to input val
+		HashMap<String, String> pipToInputVal = new HashMap<String, String>();
 		
 		// Iterate over the list of used site pips, and store them in the site
 		for(int i = 2; i < toks.length; i++) {
@@ -615,9 +618,14 @@ public class XdcRoutingInterface {
 			usedSitePips.add(wireEnum); 	
 			usedSitePips.add(conn.getSinkWire().getWireEnum());
 			// tryGetWireEnum(pipWireName.split("\\.")[0] + ".OUT")
+			String[] vals = toks[i].split(":");
+			assert vals.length == 2;
+			pipToInputVal.put(vals[0], vals[1]);
 		}
 		
 		design.setUsedSitePipsAtSite(site, usedSitePips);
+		design.addPIPInputValsAtSite(site, pipToInputVal);
+		
 	}
 	
 	/**

--- a/src/main/java/edu/byu/ece/rapidSmith/util/FamilyBuilders.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/FamilyBuilders.java
@@ -134,7 +134,6 @@ public class FamilyBuilders {
 
 		addTilesClass(clazz);
 		addSitesClass(clazz);
-		BlockStmt blockStmt = clazz.addStaticInitializer();
 
 		BlockStmt userStatements = clazz.addStaticInitializer();
 		Node staticBlock = userStatements.getParentNode().get();

--- a/src/test/java/design/assembly/MacroTests.java
+++ b/src/test/java/design/assembly/MacroTests.java
@@ -20,7 +20,6 @@
 package design.assembly;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;

--- a/src/test/java/design/subsite/CellNetTest.java
+++ b/src/test/java/design/subsite/CellNetTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * unit test for the CellNet class in RapidSmith2
  * @author Mark Crossen
  */
-class CellNetTests {
+class CellNetTest {
 
     // The cell library is needed to create different types of pins. These pins are found by creating various Cells.
     private static CellLibrary cell_library;
@@ -62,7 +62,7 @@ class CellNetTests {
     }
 
     /**
-     * Test if a Net carries a clock signal by connecting and siconnecting a clock pin.
+     * Test if a Net carries a clock signal by connecting and disconnecting a clock pin.
      */
     @Test
     @DisplayName("test cellNet 'isClkNet' method")


### PR DESCRIPTION
Here is a summary of the changes:
CellDesign.java:
For routing purposes, it is necessary to know the values of several muxes within a site. This is what the added code is intended to provide.
CellNet.java:
When importing I noticed a lot of the time was spent on a particular method getAllSourcePins(). I created a caching system so it remembers all the sourcePins and does not build the list again if it has already been built.
CellPin.java:
Changes listed in issue #247. @DallonTG thought it would be useful just to include in this pull request.
RouteTree.java:
Added in method to assure that cost never goes negative (you might not want or need this). Also added a handy toRouteString() methods for debugging purposes.
PIP.java
Added a method to return the PIP name as it appears in Vivado.
SiteWire.java:
Added some getters for some variables.
Tile.java:
Changed hashCode method so that it runs faster (needed for my routing code).
TileType.java:
Added a getter for the name.
TileWire.java:
Added some getters for some variables.
Wire.java:
Added some getters for some variables.
XdcRoutingInterface.java:
Added code to remember mux values in a site. See changes for CellDesign.java




