### PR TITLE
Make tests no longer use JUnitPlatform runner

### DIFF
--- a/src/test/java/design/assembly/MacroTests.java
+++ b/src/test/java/design/assembly/MacroTests.java
@@ -20,7 +20,6 @@
 package design.assembly;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -33,8 +32,6 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import static org.junit.jupiter.api.Assertions.*;
 
 import edu.byu.ece.rapidSmith.design.NetType;
@@ -48,7 +45,6 @@ import edu.byu.ece.rapidSmith.design.subsite.CellPinType;
 /**
  *	Tests macro cell functionality in RapidSmith
  */
-@RunWith(JUnitPlatform.class)
 public class MacroTests {
 	
 	private static CellLibrary libCells;

--- a/src/test/java/design/assembly/OverviewTest.java
+++ b/src/test/java/design/assembly/OverviewTest.java
@@ -26,8 +26,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.platform.runner.JUnitPlatform;
 import static org.junit.jupiter.api.Assertions.*;
 import edu.byu.ece.rapidSmith.util.DotFilePrinter;
 import edu.byu.ece.rapidSmith.RSEnvironment;
@@ -45,7 +43,6 @@ import edu.byu.ece.rapidSmith.design.NetType;
  * tests overview of design creation in RapidSmith2
  * @author Mark Crossen
  */
-@RunWith(JUnitPlatform.class)
 public class OverviewTest {
 
     private static CellLibrary libCells;

--- a/src/test/java/design/assembly/PropertyTests.java
+++ b/src/test/java/design/assembly/PropertyTests.java
@@ -22,8 +22,6 @@ package design.assembly;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import static org.junit.jupiter.api.Assertions.*;
 
 import edu.byu.ece.rapidSmith.RSEnvironment;
@@ -49,7 +47,6 @@ import java.util.Set;
 /**
  * This class holds unit tests for {@link PropertyList} objects.
  */
-@RunWith(JUnitPlatform.class)
 public class PropertyTests {
 
 	/** CellLibrary object used for testing*/

--- a/src/test/java/design/rscpImport/DesignVerificationTests.java
+++ b/src/test/java/design/rscpImport/DesignVerificationTests.java
@@ -19,16 +19,13 @@ package design.rscpImport;
  * also get a copy of the license at <http://www.gnu.org/licenses/>.
  */
 
-import org.junit.runner.RunWith;
 import org.junit.jupiter.api.Tag;
-import org.junit.platform.runner.JUnitPlatform;
 
 /**
  * This class holds RSCP import tests.
  */
 public class DesignVerificationTests {
 	
-	@RunWith(JUnitPlatform.class)
 	@Tag("slow")
 	public static class SuperCounterTest extends DesignVerificationTest {
 		@Override
@@ -42,7 +39,6 @@ public class DesignVerificationTests {
 		}
 	}
 	
-	@RunWith(JUnitPlatform.class)
 	@Tag("slow")
 	public static class count16Test extends DesignVerificationTest {
 		@Override
@@ -56,7 +52,6 @@ public class DesignVerificationTests {
 		}
 	}
 	
-	@RunWith(JUnitPlatform.class)
 	@Tag("slow")
 	public static class cordicTest extends DesignVerificationTest {
 		@Override

--- a/src/test/java/design/rscpImport/EdifTests.java
+++ b/src/test/java/design/rscpImport/EdifTests.java
@@ -21,8 +21,6 @@ package design.rscpImport;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import edu.byu.ece.rapidSmith.interfaces.vivado.EdifInterface;
 import edu.byu.ece.rapidSmith.util.Exceptions;
@@ -34,14 +32,11 @@ import java.io.IOException;
 /**
  * This class is used to test the {@link EdifInterface}. Add tests as necessary.
  */
-@RunWith(JUnitPlatform.class)
 public class EdifTests {
 
 	@Test
 	@DisplayName("Parse Exception")
 	public void exceptionTest() throws IOException {
-		//String expectedMessage = "java.io.FileNotFoundException: bogusEdifFile.edf (The system cannot find the file specified)";
 		assertThrows(Exceptions.ParseException.class, () -> EdifInterface.parseEdif("bogusEdifFile.edf", null));
-		//assertEquals(expectedMessage, exception.getMessage(), "Wrong exception message thrown.");
 	}
 }

--- a/src/test/java/design/rscpImport/ImportTests.java
+++ b/src/test/java/design/rscpImport/ImportTests.java
@@ -5,8 +5,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.byu.ece.rapidSmith.RSEnvironment;
@@ -22,7 +20,6 @@ import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoInterface;
  * repository. Add a new test to this directory for each test benchmark that is added
  * to the src/test/resources folder. 
  */
-@RunWith(JUnitPlatform.class)
 public class ImportTests {
 	private static final Path testDirectory = RSEnvironment.defaultEnv().getEnvironmentPath()
 			.resolve("src")

--- a/src/test/java/design/subsite/CellTest.java
+++ b/src/test/java/design/subsite/CellTest.java
@@ -28,8 +28,6 @@
  import org.junit.jupiter.api.BeforeAll;
  import org.junit.jupiter.api.DisplayName;
  import org.junit.jupiter.api.Test;
- import org.junit.runner.RunWith;
- import org.junit.platform.runner.JUnitPlatform;
  import static org.junit.jupiter.api.Assertions.*;
  import edu.byu.ece.rapidSmith.RSEnvironment;
  import edu.byu.ece.rapidSmith.device.Device;
@@ -49,7 +47,6 @@
   * jUnit test for the Cell class in RapidSmith2
   * @author Mark Crossen
   */
- @RunWith(JUnitPlatform.class)
  public class CellTest {
 
      private static Device device;

--- a/src/test/java/design/tcpExport/RoutethroughInserterTest.java
+++ b/src/test/java/design/tcpExport/RoutethroughInserterTest.java
@@ -22,8 +22,6 @@ package design.tcpExport;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import edu.byu.ece.rapidSmith.RSEnvironment;
 import edu.byu.ece.rapidSmith.design.NetType;
@@ -51,7 +49,6 @@ import java.util.Queue;
  * Tests the {@link LutRoutethroughInserter} to verify that LUT routethroughs
  * are correctly created on design export. 
  */
-@RunWith(JUnitPlatform.class)
 public class RoutethroughInserterTest {
 	
 	// Objects needed for the test 

--- a/src/test/java/device/LoadingDeviceTests.java
+++ b/src/test/java/device/LoadingDeviceTests.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import static org.junit.jupiter.api.Assertions.*;
 
 import edu.byu.ece.rapidSmith.RSEnvironment;
@@ -34,7 +32,6 @@ import edu.byu.ece.rapidSmith.util.Exceptions;
  * 
  *
  */
-@RunWith(JUnitPlatform.class)
 public class LoadingDeviceTests {
 
 	/**

--- a/src/test/java/device/PackagePinTests.java
+++ b/src/test/java/device/PackagePinTests.java
@@ -20,8 +20,6 @@
 package device;
 
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.junit.jupiter.api.DisplayName;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -41,7 +39,6 @@ import edu.byu.ece.rapidSmith.device.creation.DeviceGenerator;
 /**
  * Tests a variety of package pin methods for a device
  */
-@RunWith(JUnitPlatform.class)
 public class PackagePinTests {
 
 	private static final Path resourceDir = RSEnvironment.defaultEnv()

--- a/src/test/java/device/PartNameTests.java
+++ b/src/test/java/device/PartNameTests.java
@@ -21,8 +21,6 @@ package device;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import edu.byu.ece.rapidSmith.util.PartNameTools;
 
@@ -36,7 +34,6 @@ import java.util.List;
  * come in a variety of formats, and these tests verify that all formats
  * can be handled.
  */
-@RunWith(JUnitPlatform.class)
 public class PartNameTests {
 
 	/**

--- a/src/test/java/device/PipNameTest.java
+++ b/src/test/java/device/PipNameTest.java
@@ -28,15 +28,12 @@ import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * 
  */
-@RunWith(JUnitPlatform.class)
 public class PipNameTest {
 
 	/**

--- a/src/test/java/examples/ImportExportExampleTest.java
+++ b/src/test/java/examples/ImportExportExampleTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 import edu.byu.ece.rapidSmith.RSEnvironment;
 import edu.byu.ece.rapidSmith.examples.ImportExportExample;
@@ -42,7 +40,6 @@ import edu.byu.ece.rapidSmith.examples.ImportExportExample;
  * jUnit test for the ImportExportExample class in RapidSmith2
  * @author Dallon Glick
  */
-@RunWith(JUnitPlatform.class)
 public class ImportExportExampleTest {
 	private static ImportExportExample example;
 	private static final Path testDirectory = RSEnvironment.defaultEnv().getEnvironmentPath()


### PR DESCRIPTION
See issue #283. 

Since we upgraded to JUnit5 GA, I don't think we need the `@RunWith(JUnitPlatform.class)` annotation for any of our tests now.

There were some warnings being printed whenever gradle ran the tests, saying that it was ignoring test classes using the JUnitPlatform runner.

I got rid of the annotations, removing the warnings.