### PR TITLE
Renamed wire.getWireName, wire.getFullWireName, & site.getSitePin

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/device/BelPin.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/BelPin.java
@@ -127,7 +127,7 @@ public final class BelPin implements Serializable {
 		Site site = bel.getSite();
 		SiteType siteType = getBel().getId().getSiteType();
 		return template.getSitePins().stream()
-				.map(sitePinName -> site.getSitePin(siteType, sitePinName))
+				.map(sitePinName -> site.getPin(siteType, sitePinName))
 				.collect(Collectors.toSet());
 	}
 

--- a/src/main/java/edu/byu/ece/rapidSmith/device/PIP.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/PIP.java
@@ -113,7 +113,7 @@ public final class PIP implements Serializable {
 	 * @return An XDL-compatible string of this PIP
 	 */
 	public String toString() {
-		return "pip " + startWire.getTile().getName() + " " + startWire.getWireName() +
-				" -> " + endWire.getWireName();
+		return "pip " + startWire.getTile().getName() + " " + startWire.getName() +
+				" -> " + endWire.getName();
 	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
@@ -589,8 +589,8 @@ public final class Site implements Serializable{
 	 * @param pinName the name of the pin to create
 	 * @return the pin on this site with the specified name
 	 */
-	public SitePin getSitePin(String pinName) {
-		return getSitePin(getTemplate(), pinName);
+	public SitePin getPin(String pinName) {
+		return getPin(getTemplate(), pinName);
 	}
 
 	/**
@@ -599,11 +599,11 @@ public final class Site implements Serializable{
 	 * @param pinName the name of the pin to create
 	 * @return the pin on this site with the specified name
 	 */
-	public SitePin getSitePin(SiteType type, String pinName) {
-		return getSitePin(getTemplate(type), pinName);
+	public SitePin getPin(SiteType type, String pinName) {
+		return getPin(getTemplate(type), pinName);
 	}
 
-	private SitePin getSitePin(SiteTemplate template, String pinName) {
+	private SitePin getPin(SiteTemplate template, String pinName) {
 		SitePinTemplate pinTemplate = template.getSinks().get(pinName);
 		if (pinTemplate == null)
 			pinTemplate = template.getSources().get(pinName);

--- a/src/main/java/edu/byu/ece/rapidSmith/device/SiteWire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/SiteWire.java
@@ -73,13 +73,13 @@ public class SiteWire implements Wire, Serializable {
 	}
 
 	@Override
-	public String getWireName() {
+	public String getName() {
 		return getTile().getDevice().getWireEnumerator().getWireName(wire);
 	}
 
 	@Override
-	public String getFullWireName() {
-		return getSite().getName() + "/" + getWireName();
+	public String getFullName() {
+		return getSite().getName() + "/" + getName();
 	}
 
 	@Override

--- a/src/main/java/edu/byu/ece/rapidSmith/device/TileWire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/TileWire.java
@@ -58,13 +58,13 @@ public class TileWire implements Wire, Serializable {
 	}
 
 	@Override
-	public String getWireName() {
+	public String getName() {
 		return tile.getDevice().getWireEnumerator().getWireName(wire);
 	}
 
 	@Override
-	public String getFullWireName() {
-		return getTile().getName() + "/" + getWireName();
+	public String getFullName() {
+		return getTile().getName() + "/" + getName();
 	}
 	
 	/**

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Wire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Wire.java
@@ -31,8 +31,8 @@ import java.util.Collection;
  */
 public interface Wire extends Serializable {
 	int getWireEnum();
-	String getWireName();
-	String getFullWireName();
+	String getName();
+	String getFullName();
 	Tile getTile();
 	Site getSite();
 

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
@@ -32,7 +32,6 @@ import edu.byu.ece.rapidSmith.design.subsite.CellPin;
 import edu.byu.ece.rapidSmith.design.subsite.Property;
 import edu.byu.ece.rapidSmith.design.subsite.RouteTree;
 import edu.byu.ece.rapidSmith.device.BelPin;
-import edu.byu.ece.rapidSmith.device.PIP;
 import edu.byu.ece.rapidSmith.device.BelId;
 import edu.byu.ece.rapidSmith.device.SitePin;
 import org.jdom2.JDOMException;
@@ -222,17 +221,17 @@ public class DesignAnalyzer {
 		
 		// Always print first wire at the head of a net's RouteTree. The format is "tileName/wireName".
 		if (head)
-			s = "<head>" + rt.getWire().getFullWireName();
+			s = "<head>" + rt.getWire().getFullName();
 		
 
 		// The connection member of the RouteTree object describes the connection between this RouteTree and its predecessor.
 		// The connection may be a programmable connection (PIP or route-through) or it may be a non-programmable connection.  
 		// Look upstream and, if it was a programmable connection, include it.
 		else if (rt.getConnection().isPip() || rt.getConnection().isRouteThrough())
-			s = " " + rt.getWire().getFullWireName();
+			s = " " + rt.getWire().getFullName();
 		// It is a non-programmable connection - append it with marker.
 		else  
-			s += "=" + rt.getWire().getWireName();
+			s += "=" + rt.getWire().getName();
 
 		// Now, let's look downstream and see where to go and what to print.
 		// If it is a leaf cell, it either: 

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DeviceAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DeviceAnalyzer.java
@@ -49,7 +49,7 @@ public class DeviceAnalyzer {
 	
 	private static void printWire(Wire w) {
 		Tile t = w.getTile();
-		msg("Wire " + w.getFullWireName() + " has " + w.getWireConnections().size() + " connections."); 
+		msg("Wire " + w.getFullName() + " has " + w.getWireConnections().size() + " connections.");
 
 		/*
 		 * A wire has a number of connections to other wires. 
@@ -74,10 +74,10 @@ public class DeviceAnalyzer {
 			if (c.getSinkWire().getTile() != t) {	 
 				int xoff = c.getSinkWire().getTile().getColumn() - t.getColumn() ;	 
 				int yoff = c.getSinkWire().getTile().getRow() - t.getRow() ;	 
-				s = c.getSinkWire().getTile().toString() + "/" + c.getSinkWire().getWireName() + " [" + yoff + "," + xoff + "]";	 
+				s = c.getSinkWire().getTile().toString() + "/" + c.getSinkWire().getName() + " [" + yoff + "," + xoff + "]";
 			}	
 			else	 
-				s = c.getSinkWire().getWireName();	 
+				s = c.getSinkWire().getName();
 			if (c.isPip())	
 				msg("  [PIP] " + s);	 
 			else

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/handRouter/HandRouter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/handRouter/HandRouter.java
@@ -169,12 +169,12 @@ public class HandRouter {
 	 * @param wire {@link Wire} object to print the connections for
 	 */
 	private void printDownhillConnections ( Wire wire ) {
-		System.out.println("All connections for wire: " + wire.getFullWireName());
+		System.out.println("All connections for wire: " + wire.getFullName());
 		int i = 1;
 		
 		for (Connection conn : wire.getWireConnections()) {
 			Wire sinkWire = conn.getSinkWire();
-			System.out.println(String.format(String.format("  %d.) %s %s", i, sinkWire.getFullWireName(), conn.isPip() ?"(PIP)" : "")));
+			System.out.println(String.format(String.format("  %d.) %s %s", i, sinkWire.getFullName(), conn.isPip() ?"(PIP)" : "")));
 			i++;
 		}
 	}

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/ise/XDLWriter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/ise/XDLWriter.java
@@ -409,7 +409,7 @@ public class XDLWriter {
 		netPips.sort(new PIPComparator());
 		for (PIP pip : netPips)
 			out.append(ind + "pip " + pip.getTile().getName() + " " +
-					pip.getStartWire().getWireName() + " -> " + pip.getEndWire().getWireName() + " ," + nl);
+					pip.getStartWire().getName() + " -> " + pip.getEndWire().getName() + " ," + nl);
 	}
 
 	// Comparators for XDL ordering
@@ -429,9 +429,9 @@ public class XDLWriter {
 		public int compare(PIP t1, PIP t2) {
 			int cmp = t1.getTile().getName().compareTo(t2.getTile().getName());
 			if (cmp != 0) return cmp;
-			cmp = t1.getStartWire().getWireName().compareTo(t2.getStartWire().getWireName());
+			cmp = t1.getStartWire().getName().compareTo(t2.getStartWire().getName());
 			if (cmp != 0) return cmp;
-			return t1.getEndWire().getWireName().compareTo(t2.getEndWire().getWireName());
+			return t1.getEndWire().getName().compareTo(t2.getEndWire().getName());
 		}
 	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
@@ -346,7 +346,7 @@ public class XdcRoutingInterface {
 		
 		// Using the pip map, recreate each route as a RouteTree object
 		List<SitePin> pinsToRemove = new ArrayList<SitePin>(); 
-		//System.out.println(net.getSourceSitePins().size() + " " + net.getSourceSitePin().getName() + " " + net.getSourceSitePin().getExternalWire().getFullWireName());
+		//System.out.println(net.getSourceSitePins().size() + " " + net.getSourceSitePin().getName() + " " + net.getSourceSitePin().getExternalWire().getFullName());
 		for (SitePin sitePin : net.getSourceSitePins()) {
 			RouteTree netRouteTree = recreateRoutingNetwork2(net, sitePin.getExternalWire(), pipMap);
 			
@@ -435,7 +435,7 @@ public class XdcRoutingInterface {
 				}
 				
 				if (conn.isPip()) { 
-					if (pipMap.getOrDefault(sourceWire.getFullWireName(), emptySet).contains(sinkWire.getFullWireName())) {
+					if (pipMap.getOrDefault(sourceWire.getFullName(), emptySet).contains(sinkWire.getFullName())) {
 						this.pipUsedInRoute = true;
 						connectionCount++;
 						RouteTree sinkTree = routeTree.addConnection(conn);
@@ -604,7 +604,7 @@ public class XdcRoutingInterface {
 				continue;
 			}
 			
-			assert (connList.size() == 1) : "Site Pip wires should have exactly one connection " + sw.getWireName() + " " + connList.size() ;
+			assert (connList.size() == 1) : "Site Pip wires should have exactly one connection " + sw.getName() + " " + connList.size() ;
 			
 			Connection conn = connList.iterator().next();
 			
@@ -979,7 +979,7 @@ public class XdcRoutingInterface {
 	 */
 	private SitePin tryGetSitePin(Site site, String pinName) {
 		
-		SitePin pin = site.getSitePin(pinName);
+		SitePin pin = site.getPin(pinName);
 		
 		if (pin == null) {
 			throw new ParseException(String.format("SitePin: \"%s/%s\" does not exist in the current device\n"
@@ -1149,7 +1149,7 @@ public class XdcRoutingInterface {
 			
 		while ( true ) {
 			Tile t = currentRoute.getWire().getTile();
-			routeString = routeString.concat(t.getName() + "/" + currentRoute.getWire().getWireName() + " ");
+			routeString = routeString.concat(t.getName() + "/" + currentRoute.getWire().getName() + " ");
 						
 			// children may be changed in the following loop, so make a copy
 			ArrayList<RouteTree> children = new ArrayList<RouteTree>(currentRoute.getSinkTrees());

--- a/src/main/java/edu/byu/ece/rapidSmith/util/DeviceDiffer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/DeviceDiffer.java
@@ -103,20 +103,20 @@ public class DeviceDiffer {
 //		Map<String, PIPRouteThrough> unseenRouteThroughs =
 //				new HashMap<>(deviceTest.getRouteThroughMap().size());
 //		for (WireConnection wc : deviceTest.getRouteThroughMap().keySet()) {
-//			unseenRouteThroughs.put(weTest.getWireName(wc.getWire()),
+//			unseenRouteThroughs.put(weTest.getName(wc.getWire()),
 //					deviceTest.getRouteThrough(wc));
 //		}
 //		for (WireConnection goldWc : deviceGold.getRouteThroughMap().keySet()) {
 //			PIPRouteThrough testRT = unseenRouteThroughs.remove(
-//					weGold.getWireName(goldWc.getWire()));
+//					weGold.getName(goldWc.getWire()));
 //			if (testRT == null) {
-//				differences.add("routethrough", weGold.getWireName(goldWc.getWire()),
+//				differences.add("routethrough", weGold.getName(goldWc.getWire()),
 //						"none");
 //				continue;
 //			}
 //
 //			if (deviceGold.getRouteThrough(goldWc).getType() != testRT.getType()) {
-//				differences.down("routethrough", weGold.getWireName(goldWc.getWire()));
+//				differences.down("routethrough", weGold.getName(goldWc.getWire()));
 //				differences.add("type", "" + deviceGold.getRouteThrough(goldWc).getType(),
 //						"" + testRT.getType());
 //				differences.up();
@@ -221,12 +221,12 @@ public class DeviceDiffer {
 		Set<String> sources = new HashSet<>();
 		if (test.getSources() != null) {
 			for (Wire source : test.getSources()) {
-				sources.add(source.getWireName());
+				sources.add(source.getName());
 			}
 		}
 		if (gold.getSources() != null) {
 			for (Wire source : gold.getSources()) {
-				String sourceName = source.getWireName();
+				String sourceName = source.getName();
 				if (!sources.remove(sourceName)) {
 					differences.add("source", sourceName, "none");
 				}
@@ -241,12 +241,12 @@ public class DeviceDiffer {
 		Set<String> sinks = new HashSet<>();
 		if (test.getSinks() != null) {
 			sinks.addAll(test.getSinks().stream()
-					.map(Wire::getWireName)
+					.map(Wire::getName)
 					.collect(Collectors.toList()));
 		}
 		if (gold.getSinks() != null) {
 			for (Wire sink : gold.getSinks()) {
-				String sinkName = sink.getWireName();
+				String sinkName = sink.getName();
 				if (!sinks.remove(sinkName)) {
 					differences.add("sinkPin", sinkName, "none");
 				}
@@ -274,8 +274,8 @@ public class DeviceDiffer {
 //			if (!unseenPins.remove(pinName)) {
 //				differences.add("pin", pinName, "none");
 //			} else {
-//				String goldPinWireName = weGold.getWireName(gold.getPins().get(pinName));
-//				String testPinWireName = weTest.getWireName(test.getPins().get(pinName));
+//				String goldPinWireName = weGold.getName(gold.getPins().get(pinName));
+//				String testPinWireName = weTest.getName(test.getPins().get(pinName));
 //				if (!goldPinWireName.equals(testPinWireName)) {
 //					differences.down("pin", pinName);
 //					differences.add("pinWire", goldPinWireName, testPinWireName);

--- a/src/main/java/edu/byu/ece/rapidSmith/util/DotFilePrinter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/DotFilePrinter.java
@@ -308,7 +308,7 @@ public class DotFilePrinter {
 		while (!rtQueue.isEmpty()) {
 			RouteTree tmp = rtQueue.poll();
 			
-			builder.append(String.format(" %d [label=\"%s\"]\n", nodeIds.get(tmp), tmp.getWire().getFullWireName()));
+			builder.append(String.format(" %d [label=\"%s\"]\n", nodeIds.get(tmp), tmp.getWire().getFullName()));
 			
 			// only print edges if the route tree has any
 			if (!tmp.isLeaf()) {

--- a/src/main/java/edu/byu/ece/rapidSmith/util/RapidSmithDebug.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/RapidSmithDebug.java
@@ -58,7 +58,7 @@ public final class RapidSmithDebug {
 	 */
 	private static void printRouteTree(RouteTree rt, int level) {
 		Wire w = rt.getWire();
-		System.out.print(w.getTile() + "/" + w.getWireName());
+		System.out.print(w.getTile() + "/" + w.getName());
 		
 		if (w.getConnectedPin() != null) {
 			System.out.print(" (SitePin)");
@@ -114,7 +114,7 @@ public final class RapidSmithDebug {
 
 			for (RouteTree routeTree : rt.getFirstSource()) {
 				Wire w = routeTree.getWire();
-				cmd += w.getTile().getName() + "/" + w.getWireName() + " ";
+				cmd += w.getTile().getName() + "/" + w.getName() + " ";
 			}
 		}
 		cmd += "}]";

--- a/src/main/java/edu/byu/ece/rapidSmith/util/XDLRCOutputter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/XDLRCOutputter.java
@@ -795,7 +795,7 @@ public class XDLRCOutputter {
 		@Override
 		public int compare(Connection o1, Connection o2) {
 			return Comparator.comparing((Connection o) -> o.getSinkWire().getTile().getName())
-					.thenComparing(o -> o.getSinkWire().getWireName())
+					.thenComparing(o -> o.getSinkWire().getName())
 					.compare(o1, o2);
 		}
 	}

--- a/src/main/java/edu/byu/ece/rapidSmith/util/XDLRCOutputter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/util/XDLRCOutputter.java
@@ -227,7 +227,7 @@ public class XDLRCOutputter {
 
 		if (writeWires) {
 			List<String> wireNames = tile.getWires().stream()
-					.map(Wire::getWireName)
+					.map(Wire::getName)
 					.collect(Collectors.toCollection(ArrayList<String>::new));
 			if (forceOrdering)
 				Collections.sort(wireNames);
@@ -254,7 +254,7 @@ public class XDLRCOutputter {
 						Wire sinkWire = c.getSinkWire();
 						out.append(ind + ind + ind + "(conn ");
 						out.append(sinkWire.getTile() + " ");
-						out.append(sinkWire.getWireName() + ")" + nl);
+						out.append(sinkWire.getName() + ")" + nl);
 					}
 					out.append(ind + ind + ")" + nl);
 				}
@@ -277,7 +277,7 @@ public class XDLRCOutputter {
 					out.append(tile.getName() + " ");
 					out.append(wireName + " ");
 					out.append(isBidirectionalPip(sourceWire, c.getSinkWire()) ? "=- " : "-> ");
-					out.append(c.getSinkWire().getWireName());
+					out.append(c.getSinkWire().getName());
 
 					PIPRouteThrough rt = tile.getDevice().getRouteThrough(sourceWire, c.getSinkWire());
 					if (rt != null) {

--- a/src/test/java/design/rscpImport/DesignVerificationTest.java
+++ b/src/test/java/design/rscpImport/DesignVerificationTest.java
@@ -336,7 +336,7 @@ public abstract class DesignVerificationTest {
 			RouteTree next = rtIterator.next();
 			Wire nextWire = next.getWire();
 			
-			String fullWireName = nextWire.getTile().getName() + "/" + nextWire.getWireName();
+			String fullWireName = nextWire.getTile().getName() + "/" + nextWire.getName();
 			
 			assertTrue(wiresInNet.contains(fullWireName), 
 					String.format("Routing import failure: \nWire \"%s\" does not exist in net \"%s\"\n", fullWireName, net.getName()));


### PR DESCRIPTION
This PR addresses issues #237 and #238.

wire.getWireName() is now wire.getName().
wire.getFullWireName() is now wire.getFullName().
site.getSitePin() is now site.getPin().

Renaming these methods is obviously not backwards-compatible friendly.