### PR TITLE
Renamed methods suggested in issues #268, #269, #270

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/RouteTree.java
@@ -133,16 +133,34 @@ public final class RouteTree implements
 	/**
 	 * Returns the SitePin connected to the wire of this node. If no SitePin
 	 * object is connected, null is returned.
+	 * @deprecated Use {@link #getConnectedSitePin()} instead
 	 */
 	public SitePin getConnectingSitePin() {
+		return getConnectedSitePin();
+	}
+
+	/**
+	 * Returns the SitePin connected to the wire of this node. If no SitePin
+	 * object is connected, null is returned.
+	 */
+	public SitePin getConnectedSitePin() {
 		return wire.getConnectedPin();
 	}
 	
 	/**
 	 * Returns the BelPin connected to the wire of the RouteTree. If no BelPin
 	 * object is connected, null is returned.
+	 * @deprecated Use {@link #getConnectedBelPin()} instead
 	 */
 	public BelPin getConnectingBelPin() {
+		return getConnectedBelPin();
+	}
+
+	/**
+	 * Returns the BelPin connected to the wire of the RouteTree. If no BelPin
+	 * object is connected, null is returned.
+	 */
+	public BelPin getConnectedBelPin() {
 		return wire.getTerminal();
 	}
 
@@ -251,7 +269,7 @@ public final class RouteTree implements
 	/**
 	 * Iterates over all trees in this route tree starting from this node in a
 	 * prefix order, ie. parent nodes are guaranteed to be visited prior to the
-	 * children.  Nodes in the tree prior to this node are not traversed.
+	 * children. Nodes in the tree prior to this node are not traversed.
 	 */
 	public Iterator<RouteTree> prefixIterator() {
 		return new PrefixIterator();

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Device.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Device.java
@@ -705,7 +705,7 @@ public class Device implements Serializable {
 					}
 					extConns.put(siteType, sitePinMapPool.add(typeExternalConnections));
 				}
-				site.setExternalWireToPinNameMap(extConnPool.add(extConns));
+				site.setExternalWireToPinMap(extConnPool.add(extConns));
 			}
 
 			tile.setWireSites(wireSitesPool.add(wireSites));

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
@@ -57,7 +57,7 @@ public final class Site implements Serializable{
 	 * Map of the site pin each wire connecting to the site connects to for each
 	 * site type this site can be represented as.
 	 */
-	private Map<SiteType, Map<Integer, SitePinTemplate>> externalWireToPinNameMap;
+	private Map<SiteType, Map<Integer, SitePinTemplate>> externalWireToPinMap;
 
 	/**
 	 * Constructor unnamed, tileless site.
@@ -620,7 +620,7 @@ public final class Site implements Serializable{
 	 *   null if the wire connects to no pins on this site
 	 */
 	SitePin getSitePinOfExternalWire(SiteType type, int wire) {
-		SitePinTemplate pinTemplate = externalWireToPinNameMap.get(type).get(wire);
+		SitePinTemplate pinTemplate = externalWireToPinMap.get(type).get(wire);
 		if (pinTemplate == null)
 			return null;
 		int externalWire = getExternalWire(type, pinTemplate.getName());
@@ -636,8 +636,8 @@ public final class Site implements Serializable{
 	 */
 	SitePin getSitePinOfInternalWire(SiteType type, int wire) {
 		SiteTemplate template = getTemplate(type);
-		Map<Integer, SitePinTemplate> internalSiteWireMap = template.getInternalSiteWireMap();
-		SitePinTemplate pinTemplate = internalSiteWireMap.get(wire);
+		Map<Integer, SitePinTemplate> internalWireToSitePinMap = template.getInternalWireToSitePinMap();
+		SitePinTemplate pinTemplate = internalWireToSitePinMap.get(wire);
 		if (pinTemplate == null)
 			return null;
 		int externalWire = getExternalWire(template.getType(), pinTemplate.getName());
@@ -685,18 +685,38 @@ public final class Site implements Serializable{
 		return externalWires;
 	}
 
+	/**
+	 * @deprecated Use {@link #getExternalWireToPinMap()} instead.
+	 */
+	@Deprecated
 	public Map<SiteType, Map<Integer, SitePinTemplate>> getExternalWireToPinNameMap() {
-		return externalWireToPinNameMap;
+		return getExternalWireToPinMap();
+	}
+	
+	public Map<SiteType, Map<Integer, SitePinTemplate>> getExternalWireToPinMap() {
+		return externalWireToPinMap;
+	}
+	
+	/**
+	 * Sets the mapping of wires to the names of the pins the wires connect to for
+	 * each possible type this site can take.
+	 * @param externalWireToPinMap the mapping of wires to pin names
+	 * @deprecated Use {@link #setExternalWireToPinMap} instead.
+	 */
+	@Deprecated
+	public void setExternalWireToPinNameMap(
+		Map<SiteType, Map<Integer, SitePinTemplate>> externalWireToPinMap) {
+		setExternalWireToPinMap(externalWireToPinMap);
 	}
 
 	/**
 	 * Sets the mapping of wires to the names of the pins the wires connect to for
 	 * each possible type this site can take.
-	 * @param externalWireToPinNameMap the mapping of wires to pin names
+	 * @param externalWireToPinMap the mapping of wires to pin names
 	 */
-	public void setExternalWireToPinNameMap(
-		Map<SiteType, Map<Integer, SitePinTemplate>> externalWireToPinNameMap) {
-		this.externalWireToPinNameMap = externalWireToPinNameMap;
+	public void setExternalWireToPinMap(
+		Map<SiteType, Map<Integer, SitePinTemplate>> externalWireToPinMap) {
+		this.externalWireToPinMap = externalWireToPinMap;
 	}
 
 	// Site compatibility

--- a/src/main/java/edu/byu/ece/rapidSmith/device/SiteTemplate.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/SiteTemplate.java
@@ -45,7 +45,7 @@ public final class SiteTemplate implements Serializable {
 	// Map of pin names to pin templates for the sink pins
 	private Map<String, SitePinTemplate> sinks;
 	// Map of site wires to the pin templates the wires connect to
-	private transient Map<Integer, SitePinTemplate> internalSiteWireMap;
+	private transient Map<Integer, SitePinTemplate> internalWireToSitePinMap;
 	// Map of the site wires to the bel pin templates the wire connect to
 	private transient Map<Integer, BelPinTemplate> belPins;
 	// Map of XDL attributes that should be created for each PIP
@@ -110,8 +110,16 @@ public final class SiteTemplate implements Serializable {
 		this.sinks = sinks;
 	}
 
+	/**
+	 * @deprecated Use {@link #getInternalWireToSitePinMap} instead.
+	 */
+	@Deprecated
 	public Map<Integer, SitePinTemplate> getInternalSiteWireMap() {
-		return internalSiteWireMap;
+		return getInternalWireToSitePinMap();
+	}
+	
+	public Map<Integer, SitePinTemplate> getInternalWireToSitePinMap() {
+		return internalWireToSitePinMap;
 	}
 
 	public Map<Integer, BelPinTemplate> getBelPins() {
@@ -122,8 +130,16 @@ public final class SiteTemplate implements Serializable {
 		this.belPins = belPins;
 	}
 
-	public void setInternalSiteWireMap(Map<Integer, SitePinTemplate> internalSiteWireMap) {
-		this.internalSiteWireMap = internalSiteWireMap;
+	/**
+	 * @deprecated Use {@link #setInternalWireToSitePinMap} instead.
+	 */
+	@Deprecated
+	public void setInternalSiteWireMap(Map<Integer, SitePinTemplate> internalWireToSitePinMap) {
+		setInternalWireToSitePinMap(internalWireToSitePinMap);
+	}
+	
+	public void setInternalWireToSitePinMap(Map<Integer, SitePinTemplate> internalWireToSitePinMap) {
+		this.internalWireToSitePinMap = internalWireToSitePinMap;
 	}
 
 	public Map<Integer, Map<Integer, XdlAttribute>> getPipAttributes() {
@@ -165,12 +181,12 @@ public final class SiteTemplate implements Serializable {
 	void constructDependentResources() {
 		// Create the internal site wire map by grabbing the internal wires
 		// for both the source and sink pins
-		internalSiteWireMap = new HashMap<>();
+		internalWireToSitePinMap = new HashMap<>();
 		for (SitePinTemplate sitePin : sources.values()) {
-			internalSiteWireMap.put(sitePin.getInternalWire(), sitePin);
+			internalWireToSitePinMap.put(sitePin.getInternalWire(), sitePin);
 		}
 		for (SitePinTemplate sitePin : sinks.values()) {
-			internalSiteWireMap.put(sitePin.getInternalWire(), sitePin);
+			internalWireToSitePinMap.put(sitePin.getInternalWire(), sitePin);
 		}
 
 		// Create the wire to bel pin maps by inferringthe information from the

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
@@ -239,8 +239,8 @@ public class DesignAnalyzer {
 		//     (2) has a BEL pin attached, or 
 		//     (3) simply ends. Wires that end like this are called "used stubs" in Vivado's GUI.  They don't go anywhere.
 		if (rt.isLeaf()) {
-			SitePin sp = rt.getConnectingSitePin();
-			BelPin bp = rt.getConnectingBelPin();
+			SitePin sp = rt.getConnectedSitePin();
+			BelPin bp = rt.getConnectedBelPin();
 			if (sp != null) {
 				// If we are at a site pin then what we do differs depending on whether we are inside the site (and leaving) or outside the site (and entering). 
 				if (inside) {  

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/LutRoutethroughInserter.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/LutRoutethroughInserter.java
@@ -155,10 +155,10 @@ public class LutRoutethroughInserter {
 			}
 			
 			if (current.getConnection().isRouteThrough()) {				
-				rtSource = current.getSourceTree().getConnectingBelPin();
+				rtSource = current.getSourceTree().getConnectedBelPin();
 			}
 			else if (current.isLeaf()) {
-				BelPin bp = current.getConnectingBelPin();
+				BelPin bp = current.getConnectedBelPin();
 				
 				// add all sinks that are not connected to LUTs
 				if (!bp.getBel().getName().endsWith("LUT")) {

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
@@ -453,7 +453,7 @@ public class XdcRoutingInterface {
 			
 			// check to see if the current route tree object is connected to a valid sink site pin 
 			// the connection count is used to filter out routethrough site pins
-			SitePin sinkSitePin = routeTree.getConnectingSitePin();
+			SitePin sinkSitePin = routeTree.getConnectedSitePin();
 			
 			if (sinkSitePin != null && connectionCount == 0 && processSitePinSink(net, sinkSitePin)) {
 				terminals.add(routeTree);

--- a/src/test/java/design/subsite/RouteTreeTest.java
+++ b/src/test/java/design/subsite/RouteTreeTest.java
@@ -75,7 +75,6 @@ class RouteTreeTest {
 	private static SiteTemplate makeSiteTemplate(SiteType dummySiteType) {
 		SiteTemplate dummySiteTemplate = new SiteTemplate();
 		dummySiteTemplate.setType(dummySiteType);
-//		dummySiteTemplate.setInternalSiteWireMap();
 
 		HashMap<String, SitePinTemplate> sinks = new HashMap<>();
 		SitePinTemplate dummySink = new SitePinTemplate("DUMMY_SINK", dummySiteType);
@@ -143,7 +142,7 @@ class RouteTreeTest {
 		e2pinMap.put(4, dummySinkTemplate);
 		e2pinMap.put(5, dummySourceTemplate);
 		e2pMap.put(dummySiteType, e2pinMap);
-		dummySite.setExternalWireToPinNameMap(e2pMap);
+		dummySite.setExternalWireToPinMap(e2pMap);
 	}
 
 	/**
@@ -302,14 +301,14 @@ class RouteTreeTest {
 		Site site = device.getTile(0).getSite(0);
 		SitePin pin = site.getSinkPin("DUMMY_SITE_PIN");
 		RouteTree t = leaf.addConnection(newDummyConnection(leaf.getWire(), 4, false));
-		assertEquals(pin, t.getConnectingSitePin());
+		assertEquals(pin, t.getConnectedSitePin());
 	}
 
 	@Test
 	@DisplayName("getConnectingSitePin is unidirectional")
 	void testGetConnectingSitePin2() {
 		RouteTree t = leaf.addConnection(newDummyConnection(leaf.getWire(), 5, false));
-		assertNull(t.getConnectingSitePin());
+		assertNull(t.getConnectedSitePin());
 	}
 
 	@Test

--- a/src/test/java/design/subsite/RouteTreeTest.java
+++ b/src/test/java/design/subsite/RouteTreeTest.java
@@ -296,8 +296,8 @@ class RouteTreeTest {
 	}
 
 	@Test
-	@DisplayName("test getConnectingSitePin method")
-	void testGetConnectingSitePin() {
+	@DisplayName("test getConnectedSitePin method")
+	void testGetConnectedSitePin() {
 		Site site = device.getTile(0).getSite(0);
 		SitePin pin = site.getSinkPin("DUMMY_SITE_PIN");
 		RouteTree t = leaf.addConnection(newDummyConnection(leaf.getWire(), 4, false));
@@ -305,8 +305,8 @@ class RouteTreeTest {
 	}
 
 	@Test
-	@DisplayName("getConnectingSitePin is unidirectional")
-	void testGetConnectingSitePin2() {
+	@DisplayName("getConnectedSitePin is unidirectional")
+	void testGetConnectedSitePin2() {
 		RouteTree t = leaf.addConnection(newDummyConnection(leaf.getWire(), 5, false));
 		assertNull(t.getConnectedSitePin());
 	}

--- a/src/test/java/design/tcpExport/RoutethroughInserterTest.java
+++ b/src/test/java/design/tcpExport/RoutethroughInserterTest.java
@@ -165,7 +165,7 @@ public class RoutethroughInserterTest {
 		while (!rtQueue.isEmpty()) {
 			RouteTree tree = rtQueue.poll();
 			
-			BelPin terminal = tree.getConnectingBelPin();
+			BelPin terminal = tree.getConnectedBelPin();
 			if (terminal != null && sink.equals(terminal)) {
 				start.prune(Collections.singleton(tree));
 				break;


### PR DESCRIPTION
Renamed the methods suggested in #268, #269, and #270. Also renamed RouteTree.getConnectingBelPin() to RouteTree.getConnectedBelPin() to make it match with RouteTree.getConnectedSitePin(). 

All methods have deprecated versions.

This build won't fail once #312 is accepted and merged.