### PR TITLE
A clean property is now added each time a cell is created.

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Cell.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Cell.java
@@ -571,18 +571,17 @@ public class Cell {
 
 		Cell cellCopy = cellFactory.apply(name, libCell);
 		cellCopy.setBonded(getBonded());
-		getProperties().forEach(p ->
-				cellCopy.properties.update(copyAttribute(getLibCell(), libCell, p))
-		);
+//		getProperties().forEach(p ->
+//				cellCopy.properties.update(copyAttribute(getLibCell(), libCell, p))
+//		);
 		return cellCopy;
 	}
 
-	private Property copyAttribute(LibraryCell oldType, LibraryCell newType, Property orig) {
-		if (!oldType.equals(newType) && orig.getKey().equals(oldType.getName())) {
-			return new Property(newType.getName(), orig.getType(), orig.getValue());
-		} else {
-			return orig.deepCopy();
-		}
+	private Property copyAttribute(Property orig) {
+		if (orig.isReadOnly())
+			return orig;
+		else
+			return orig.copy();
 	}
 
 	@Override

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
@@ -256,7 +256,7 @@ public class CellLibrary implements Iterable<LibraryCell> {
 				String[] values = valueString.isEmpty() ? new String[0] : valueString.split(", ");
 				
 				// add the configuration to the library cell
-				libCell.addDefaultProperty(new Property(name, PropertyType.EDIF, deflt));						
+				libCell.addDefaultProperty(new Property(name, PropertyType.EDIF, deflt, isReadonly, true));
 				libCell.addConfigurableProperty(new LibraryCellProperty(name, type, values, isReadonly));
 			}
 		}

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Property.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Property.java
@@ -24,15 +24,26 @@ package edu.byu.ece.rapidSmith.design.subsite;
  * A property containing a key/value pair.  A property type can be specified
  * to indicate the source and use of the property.
  */
-public class Property {
+public final class Property {
 	private final String key;
 	private PropertyType type;
 	private Object value;
+	private boolean readOnly;
+	private boolean defaultProperty;
 
 	public Property(String key, PropertyType type, Object value) {
 		this.key = key;
 		this.type = type;
 		this.value = value;
+		this.readOnly = false;
+	}
+
+	Property(String key, PropertyType type, Object value, boolean readOnly, boolean defaultProperty) {
+		this.key = key;
+		this.type = type;
+		this.value = value;
+		this.readOnly = readOnly;
+		this.defaultProperty = defaultProperty;
 	}
 
 	public String getKey() {
@@ -45,14 +56,6 @@ public class Property {
 	 */
 	public PropertyType getType() {
 		return type;
-	}
-
-	/**
-	 * Sets the property type.  The stype indicates the source of the property
-	 * and its use.
-	 */
-	public void setType(PropertyType type) {
-		this.type = type;
 	}
 
 	/**
@@ -94,14 +97,32 @@ public class Property {
 	 * Sets the value of the property
 	 */
 	public void setValue(Object value) {
+		if (isReadOnly())
+			throw new UnsupportedOperationException("Cannot update read only properties");
 		this.value = value;
+	}
+
+	/**
+	 * Returns true if this property is non-modifiable.
+	 * <p/> Note, read only properties may return mutable objects with the
+	 * {@link #getValue()} method.
+	 */
+	public boolean isReadOnly() {
+		return readOnly;
+	}
+
+	/**
+	 * Returns true if this is a property defined by a library cell.
+	 */
+	public boolean isDefaultProperty() {
+		return defaultProperty;
 	}
 
 	/**
 	 * Returns a new copy of this property with the same key/type/value.
 	 */
-	public Property deepCopy() {
-		return new Property(key, type, value);
+	public Property copy() {
+		return new Property(key, type, value, readOnly, defaultProperty);
 	}
 
 	@Override


### PR DESCRIPTION
This allows for safe updating of property values without overwriting
values of global properties.  In the case of read-only properties,
these properties cannot be updated or their value changed and only a
single instance of each read-only property is stored.

Default properties are now tagged by the property and result in an
error if the user tries to remove them from the PropertyList.

Reference issue #303 