### PR TITLE
PR/Partial Device Additions/Fixes

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
@@ -66,6 +66,8 @@ public class CellDesign extends AbstractDesign {
 	private ImplementationMode mode;
 	/** Map of used PIPs to their Input Values in a Site **/
 	private Map<Site, Map<String, String>> pipInValues;
+	/**Map of out-of-context ports to their ooc tile and node **/
+	private Map<String, String> oocPortMap;
 	
 	/**
 	 * Constructor which initializes all member data structures. Sets name and
@@ -807,5 +809,19 @@ public class CellDesign extends AbstractDesign {
 		}
 
 		return designCopy;
+	}
+
+	/**
+	 * @return the oocPortMap
+	 */
+	public Map<String, String> getOocPortMap() {
+		return oocPortMap;
+	}
+
+	/**
+	 * @param oocPortMap the oocPortMap to set
+	 */
+	public void setOocPortMap(Map<String, String> oocPortMap) {
+		this.oocPortMap = oocPortMap;
 	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/device/PIP.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/PIP.java
@@ -109,14 +109,14 @@ public final class PIP implements Serializable {
 	public String getName() {
 		StringBuilder name = new StringBuilder();
 		name.append(startWire.getTile().getName()+"/"+startWire.getTile().getType().getName()+".");
-		name.append(startWire.getWireName());
+		name.append(startWire.getName());
 		if(startWire.getTile().getType().getName().contains("CLB")){
 			name.append("->");
 		}
 		else{
 			name.append("->>");
 		}
-		name.append(endWire.getWireName());
+		name.append(endWire.getName());
 		return name.toString();
 	}
 	

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
@@ -106,6 +106,7 @@ public final class VivadoInterface {
 		String routingFile = rscpPath.resolve("routing.rsc").toString();
 		XdcRoutingInterface routingInterface = new XdcRoutingInterface(design, device, placementInterface.getPinMap(), mode);
 		routingInterface.parseRoutingXDC(routingFile);
+		design.setOocPortMap(routingInterface.getOocPortMap());
 		
 		VivadoCheckpoint vivadoCheckpoint = new VivadoCheckpoint(partName, design, device, libCells); 
 		

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
@@ -363,32 +363,28 @@ public class XdcPlacementInterface {
 				}
 			}
 			
-			// Write the partition pin locations
-			
-			
-			if (design.getImplementationMode().equals(ImplementationMode.OUT_OF_CONTEXT))
+			// If OOC mode, write the partition pin location properties
+			if (design.getImplementationMode() == ImplementationMode.OUT_OF_CONTEXT)
 			{
-				System.out.println("OOC Mode");
-				// Try to get all hierachical ports
+				// Iterate through the ooc port map to construct the properties
+				Map<String, String> oocPortMap = design.getOocPortMap();
 				
-				for (Cell cell : design.getCells())
-				{
-					if (cell.isPort())
-					{
-						System.out.println("Port: " + cell.getName());
-						//design.removeCell(cell);
-					}
-				
-				}
-				//fileout.write("set_property HD.PARTPIN_LOCS { ");
+				if (oocPortMap != null) {
+					for (Map.Entry<String, String> entry : oocPortMap.entrySet()) {
+						fileout.write("set_property HD.PARTPIN_LOCS {");
+					
+						// Write the tile the partition pin is located in
+						String[] toks = entry.getValue().split("/");
+						String tileName = toks[0];
+						fileout.write(tileName);
 
-			}
-			
-			
+						// Write the corresponding port name
+						fileout.write("} [get_ports ");
+						fileout.write(entry.getKey() + "]\n");
+					}
+				}
+			}	
 		}
-		
-		
-		
 	}
 
 	/*

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 import edu.byu.ece.rapidSmith.design.subsite.Cell;
 import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
 import edu.byu.ece.rapidSmith.design.subsite.CellPin;
+import edu.byu.ece.rapidSmith.design.subsite.ImplementationMode;
 import edu.byu.ece.rapidSmith.design.subsite.Property;
 import edu.byu.ece.rapidSmith.design.subsite.PropertyType;
 import edu.byu.ece.rapidSmith.device.Bel;
@@ -361,7 +362,33 @@ public class XdcPlacementInterface {
 					}
 				}
 			}
+			
+			// Write the partition pin locations
+			
+			
+			if (design.getImplementationMode().equals(ImplementationMode.OUT_OF_CONTEXT))
+			{
+				System.out.println("OOC Mode");
+				// Try to get all hierachical ports
+				
+				for (Cell cell : design.getCells())
+				{
+					if (cell.isPort())
+					{
+						System.out.println("Port: " + cell.getName());
+						//design.removeCell(cell);
+					}
+				
+				}
+				//fileout.write("set_property HD.PARTPIN_LOCS { ");
+
+			}
+			
+			
 		}
+		
+		
+		
 	}
 
 	/*

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
@@ -279,6 +279,11 @@ public class XdcRoutingInterface {
 		CellPin sourceCellPin = tryGetNetSource(net);
 		BelPin sourceBelPin = tryGetMappedBelPin(sourceCellPin);
 				
+		// There may be no source Bel Pin if the design was implemented out-of-context.
+		if (sourceBelPin == null) {
+			return;
+		}
+		
 		Site site = sourceBelPin.getBel().getSite();
 		createIntrasiteRoute(net, sourceBelPin, true, design.getUsedSitePipsAtSite(site));
 		net.setIsIntrasite(true);
@@ -1083,9 +1088,13 @@ public class XdcRoutingInterface {
 		
 		int mapCount = cellPin.getMappedBelPinCount(); 
 		
-		if (mapCount != 1) {
+		// Some out of context designs will not have cells, so there will be no mapped BelPin.
+		if (mapCount != 1 && implementationMode == ImplementationMode.OUT_OF_CONTEXT) {
+			return null;
+		}
+		else if (mapCount != 1) {
 			throw new ParseException(String.format("Cell pin source \"%s\" should map to exactly one BelPin, but maps to %d\n"
-												+ "On %d of %s", cellPin.getName(), mapCount, currentLineNumber, currentFile));
+					+ "On %d of %s", cellPin.getName(), mapCount, currentLineNumber, currentFile));	
 		}
 		
 		return cellPin.getMappedBelPin();

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
@@ -70,6 +70,21 @@ public class XdcRoutingInterface {
 	private Map<Bel, BelRoutethrough> belRoutethroughMap;
 	private Pattern pipNamePattern;
 	private Map<String, String> oocPortMap;
+	
+	/**
+	 * @return the oocPortMap
+	 */
+	public Map<String, String> getOocPortMap() {
+		return oocPortMap;
+	}
+
+	/**
+	 * @param oocPortMap the oocPortMap to set
+	 */
+	public void setOocPortMap(Map<String, String> oocPortMap) {
+		this.oocPortMap = oocPortMap;
+	}
+
 	private ImplementationMode implementationMode;
 	private boolean pipUsedInRoute = false;
 	


### PR DESCRIPTION
There's two parts to this PR:

1. I added a condition for OOC designs when processing intrasite routes (done when loading an RSCP). Some (very simple) out of context designs will not have cells, so there will be no mapped BelPin for a cell. This condition allows the RSCP load to continue in this case.

2. For out-of-context designs, the assumption is that any ports are OOC ports. In other words, they are partition pins. For a given out-of-context design, if there are ports, there will be a partition pin for each one. In order for the locations of the partition pins to be preserved when importing back into Vivado, the  HD.PARTPIN_LOCS property needs to be set for every port as part of placement. This specifies the tile in which the partition pin for each port will be located. 

To do this, I save the map of ooc ports that is created when the routing.rsc is parsed to the CellDesign. This map is used to create the correct set_property commands that need to be added to the placement.xdc upon design export.

Edit: I realize now that I think I made an error in my description of part 1. I will update this comment soon to provide a correct explanation of what is actually happening.