### PR TITLE
Fix macro pins which point to <const0> or <const1>

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPin.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPin.java
@@ -397,4 +397,9 @@ public abstract class CellPin implements Serializable {
 	 * @return 
 	 */
 	public abstract CellPin getExternalPin();
+
+	public void setMacroPinToGlobalNet(CellNet n) {
+		setNet(n);
+	}
+
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
@@ -457,6 +457,16 @@ public final class EdifInterface {
 		design.addNet(globalVCCNet);
 		design.addCell(globalGND);
 		design.addNet(globalGNDNet);
+		
+		// For macro pins tied to <const0> or <const1>, make them point to the appropriate global static net
+		for (Cell c : design.getCells())
+			for (CellPin cp : c.getPins()) {
+				if (cp.getNet()!= null && cp.getNet().getName().equals("<const0>"))
+					cp.setMacroPinToGlobalNet(globalGNDNet);
+				else if (cp.getNet()!= null && cp.getNet().getName().equals("<const1>"))
+					cp.setMacroPinToGlobalNet(globalVCCNet);
+			}
+
 	}
 	
 	private static void transferSinkPins(CellNet oldNet, CellNet newNet) {


### PR DESCRIPTION
After merging static nets in the edif importing, there are still macro pins pointing to nets <const0> or <const1>. This is something left over from the merging.  

Change them to point to the corresponding global Vcc or Gnd net.  This makes them similar to all other macro pins.

