### PR TITLE
Safe placement and placement cleanup

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Cell.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Cell.java
@@ -239,12 +239,19 @@ public class Cell {
 		return bel;
 	}
 
+	/**
+	 * @deprecated Use getPossibleLocations
+	 */
+	@Deprecated
 	public final List<BelId> getPossibleAnchors() {
 		return getLibCell().getPossibleAnchors();
 	}
 
-	public final List<Bel> getRequiredBels(Bel anchor) {
-		return getLibCell().getRequiredBels(anchor);
+	/**
+	 * @return the possible types of BELs this cell can be placed on.
+	 */
+	public final List<BelId> getPossibleLocations() {
+		return getLibCell().getPossibleAnchors();
 	}
 
 	/**

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
@@ -591,7 +591,18 @@ public class CellDesign extends AbstractDesign {
 	 * @param bel the BEL where the cell is to be placed
 	 */
 	public void placeCell(Cell cell, Bel bel) {
-		placeCell(cell, bel);
+		Objects.requireNonNull(cell);
+		Objects.requireNonNull(bel);
+		if (cell.getDesign() != this)
+			throw new Exceptions.DesignAssemblyException("Cannot place cell not in the design.");
+		if (cell.isPlaced())
+			throw new Exceptions.DesignAssemblyException("Cell is already placed. Cannot re-place cell: " + cell.getName());
+		if (cell.isMacro())
+			throw new Exceptions.DesignAssemblyException("Cannot place macro cell. Can only place internal cells to the macro.");
+		if (isBelUsed(bel))
+			throw new Exceptions.DesignAssemblyException("Cell already placed at location.");
+
+		_placeCell(cell, bel);
 	}
 
 	/**

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
@@ -23,11 +23,13 @@ package edu.byu.ece.rapidSmith.design.subsite;
 import edu.byu.ece.rapidSmith.design.AbstractDesign;
 import edu.byu.ece.rapidSmith.device.Bel;
 import edu.byu.ece.rapidSmith.device.Site;
-import edu.byu.ece.rapidSmith.util.Exceptions;
 import edu.byu.ece.rapidSmith.interfaces.vivado.XdcConstraint;
+import edu.byu.ece.rapidSmith.util.Exceptions;
 
 import java.util.*;
 import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
 
 /**
  *  This class represents a logical netlist consisting of cells interconnected by
@@ -73,7 +75,7 @@ public class CellDesign extends AbstractDesign {
 	 */
 	public CellDesign() {
 		super();
-		init();
+		_init();
 		properties = new PropertyList();
 	}
 
@@ -86,11 +88,11 @@ public class CellDesign extends AbstractDesign {
 	 */
 	public CellDesign(String designName, String partName) {
 		super(designName, partName);
-		init();
+		_init();
 		properties = new PropertyList();
 	}
 
-	private void init() {
+	private void _init() {
 		cellMap = new HashMap<>();
 		internalCellMap = new HashMap<>();
 		placementMap = new HashMap<>();
@@ -191,7 +193,7 @@ public class CellDesign extends AbstractDesign {
 	 * are returned.
 	 */
 	public Stream<Cell> getLeafCells() {
-		return cellMap.values().stream().flatMap(c -> flatten(c));
+		return cellMap.values().stream().flatMap(c -> _flatten(c));
 	}
 	
 	/**
@@ -202,7 +204,7 @@ public class CellDesign extends AbstractDesign {
 	 * @param cell {@link Cell} object to flatten
 	 * @return A {@link Stream} of internal cells
 	 */
-	private Stream<Cell> flatten(Cell cell) {
+	private Stream<Cell> _flatten(Cell cell) {
 		return cell.isMacro() ? cell.getInternalCells().stream() : Collections.singletonList(cell).stream();
 	}
 	
@@ -246,10 +248,10 @@ public class CellDesign extends AbstractDesign {
 		if (cell.isInternal())
 			throw new Exceptions.DesignAssemblyException("Cannot add internal cell to design. Must add parent macro instead.");
 		
-		return registerCell(cell);
+		return _registerCell(cell);
 	}
 
-	private Cell registerCell(Cell cell) {
+	private Cell _registerCell(Cell cell) {
 		if (hasCell(cell.getName()))
 			throw new Exceptions.DesignAssemblyException("Cell with name already exists in design: " + cell.getName());
 
@@ -283,10 +285,10 @@ public class CellDesign extends AbstractDesign {
 		if (cell.isInternal()) 
 			throw new IllegalArgumentException("Cannot remove internal cell from the design. Remove the macro parent cell.");
 		
-		removeCell_impl(cell);
+		_removeCell(cell);
 	}
 
-	private void removeCell_impl(Cell cell) {
+	private void _removeCell(Cell cell) {
 		
 		cellMap.remove(cell.getName());
 		cell.clearDesign();
@@ -295,14 +297,14 @@ public class CellDesign extends AbstractDesign {
 		if (cell.isMacro()) {
 			for (Cell iCell: cell.getInternalCells()) {
 				iCell.clearDesign();
-				unplaceCell_impl(iCell);
+				_unplaceCell(iCell);
 				internalCellMap.remove(iCell.getName());
 			}
 			cell.getPins().stream().filter(CellPin::isConnectedToNet).forEach(p -> p.getNet().disconnectFromPin(p));
-			cell.getInternalNets().forEach(this::removeNet_impl);
+			cell.getInternalNets().forEach(this::_removeNet);
 		}
 		else {
-			disconnectCell_impl(cell);
+			_disconnectCell(cell);
 		}
 	}
 
@@ -322,17 +324,17 @@ public class CellDesign extends AbstractDesign {
 		
 		// for macros, disconnect the sub-cells
 		if (cell.isMacro()) {
-			cell.getInternalCells().forEach(this::unplaceCell_impl);
+			cell.getInternalCells().forEach(this::_unplaceCell);
 			cell.getPins().stream().filter(CellPin::isConnectedToNet).forEach(p -> p.getNet().disconnectFromPin(p));
 		}
 		else { // leaf cell
-			disconnectCell_impl(cell);
+			_disconnectCell(cell);
 		}
 	}
 
-	private void disconnectCell_impl(Cell cell) {
+	private void _disconnectCell(Cell cell) {
 
-		unplaceCell_impl(cell);
+		_unplaceCell(cell);
 
 		// disconnect the cell's pins from their nets
 		for (CellPin pin : cell.getPins()) {
@@ -398,10 +400,10 @@ public class CellDesign extends AbstractDesign {
 		if (net.isInDesign())
 			throw new Exceptions.DesignAssemblyException("Cannot add net from another design.");
 
-		return addNet_impl(net);
+		return _addNet(net);
 	}
 
-	protected CellNet addNet_impl(CellNet net) {
+	private CellNet _addNet(CellNet net) {
 		if (hasNet(net.getName()))
 			throw new Exceptions.DesignAssemblyException("Net with name already exists in design.");
 
@@ -438,10 +440,10 @@ public class CellDesign extends AbstractDesign {
 		if (!net.getPins().isEmpty())
 			throw new Exceptions.DesignAssemblyException("Cannot remove connected net." + net.getName());
 
-		removeNet_impl(net);
+		_removeNet(net);
 	}
 
-	private void removeNet_impl(CellNet net) {
+	private void _removeNet(CellNet net) {
 		net.setDesign(null);
 		
 		if (net.isVCCNet()) {
@@ -470,10 +472,10 @@ public class CellDesign extends AbstractDesign {
 		if (net.isInternal()) 
 			throw new Exceptions.DesignAssemblyException("Cannot disconnect internal net.");
 		
-		disconnectNet_impl(net);
+		_disconnectNet(net);
 	}
 
-	private void disconnectNet_impl(CellNet net) {
+	private void _disconnectNet(CellNet net) {
 		List<CellPin> pins = new ArrayList<>(net.getPins());
 		pins.forEach(net::disconnectFromPin);
 		net.unrouteFull();
@@ -571,19 +573,11 @@ public class CellDesign extends AbstractDesign {
 	 * the specified {@link Bel}.
 	 * 
 	 * @param cell {@link Cell} to place
-	 * @param anchor {@link Bel} to place the cell on
+	 * @param bel {@link Bel} to place the cell on
 	 */
-	public boolean canPlaceCellAt(Cell cell, Bel anchor) {
-		List<Bel> requiredBels = cell.getLibCell().getRequiredBels(anchor);
-		return canPlaceCellAt_impl(requiredBels);
-	}
-
-	private boolean canPlaceCellAt_impl(List<Bel> requiredBels) {
-		for (Bel bel : requiredBels) {
-			if (bel == null || isBelUsed(bel))
-				return false;
-		}
-		return true;
+	public boolean canPlaceCellAt(Cell cell, Bel bel) {
+		return bel != null && !isBelUsed(bel) &&
+			cell.getLibCell().getPossibleAnchors().contains(bel.getId());
 	}
 
 	/**
@@ -594,31 +588,55 @@ public class CellDesign extends AbstractDesign {
 	 * is finalized, and then apply the pin mappings.
 	 *
 	 * @param cell the cell to place
-	 * @param anchor the BEL where the cell is to be placed
+	 * @param bel the BEL where the cell is to be placed
 	 */
-	public void placeCell(Cell cell, Bel anchor) {
+	public void placeCell(Cell cell, Bel bel) {
+		placeCell(cell, bel);
+	}
+
+	/**
+	 * Same as {@link #placeCell(Cell, Bel)} but also checks that the BEL is a valid type for
+	 * the cell and that the type of the BEL does not clash with other BELs already used in
+	 * the site.  The type of the site is then updated to match the site type.
+	 * <p/>
+	 * When comparing against existing BELs used in the site, the check only compares against
+	 * one BEL in the site, chosen in a non-deterministic manner.
+	 *
+	 * @param cell the cell to place
+	 * @param bel the BEL where the cell is to be placed
+	 *
+	 * @throws Exceptions.DesignAssemblyException if the BEL types are incompatible
+	 */
+	public void placeCellSafe(Cell cell, Bel bel) {
 		Objects.requireNonNull(cell);
-		Objects.requireNonNull(anchor);
+		Objects.requireNonNull(bel);
 		if (cell.getDesign() != this)
 			throw new Exceptions.DesignAssemblyException("Cannot place cell not in the design.");
 		if (cell.isPlaced())
 			throw new Exceptions.DesignAssemblyException("Cell is already placed. Cannot re-place cell: " + cell.getName());
-		if (cell.isMacro()) 
+		if (cell.isMacro())
 			throw new Exceptions.DesignAssemblyException("Cannot place macro cell. Can only place internal cells to the macro.");
-		
-		List<Bel> requiredBels = cell.getLibCell().getRequiredBels(anchor);
-		if (!canPlaceCellAt_impl(requiredBels))
+		if (!canPlaceCellAt(cell, bel))
 			throw new Exceptions.DesignAssemblyException("Cell already placed at location.");
 
-		placeCell_impl(cell, anchor, requiredBels);
+		_validateCellPlacement(bel);
+		bel.getSite().setType(bel.getId().getSiteType());
+
+		_placeCell(cell, bel);
 	}
 
-	private void placeCell_impl(Cell cell, Bel anchor, List<Bel> requiredBels) {
-		requiredBels.forEach(b -> placeCellAt(cell, b));
-		cell.place(anchor);
+	// Checks that the BEL to be occupied is compatible with other used BELs in the site.
+	private void _validateCellPlacement(Bel bel) {
+		Map<Bel, Cell> existingBels = placementMap.getOrDefault(bel.getSite(), emptyMap());
+		Optional<Bel> existingType = existingBels.keySet().stream().findAny();
+		existingType.ifPresent(t -> {
+			if (t.getId().getSiteType() != bel.getId().getSiteType())
+				throw new Exceptions.DesignAssemblyException("Site types of BELs in site differ from existing");
+		});
 	}
 
-	private void placeCellAt(Cell cell, Bel bel) {
+	private void _placeCell(Cell cell, Bel bel) {
+		// update the placement map
 		Map<Bel, Cell> sitePlacementMap = placementMap.get(bel.getSite());
 		if (sitePlacementMap == null) {
 			sitePlacementMap = new HashMap<>();
@@ -627,6 +645,9 @@ public class CellDesign extends AbstractDesign {
 			assert sitePlacementMap.get(bel) == null;
 		}
 		sitePlacementMap.put(bel, cell);
+
+		// set the location in the cell
+		cell.place(bel);
 	}
 
 	/**
@@ -643,39 +664,42 @@ public class CellDesign extends AbstractDesign {
 
 		// for macros, unplace all internal cells
 		if (cell.isMacro()) {
-			cell.getInternalCells().forEach(this::unplaceCell_impl);
+			cell.getInternalCells().forEach(this::_unplaceCell);
 		}
 		else {
-			unplaceCell_impl(cell);
+			_unplaceCell(cell);
 		}
 	}
 
-	private void unplaceCell_impl(Cell cell) {
-		
+	private void _unplaceCell(Cell cell) {
 		assert(!cell.isMacro());
-		
+
+		_clearCellPlacement(cell);
+
+		// undo all cell pin mappings (if they exists)
+		cell.getPins().forEach(CellPin::clearPinMappings);
+	}
+
+	private void _clearCellPlacement(Cell cell) {
 		// if the cell is not placed, return
-		if (!cell.isPlaced()) {
+		if (!cell.isPlaced())
 			return;
-		}
-		
+
+		// remove the location from the placement map
 		Site site = cell.getSite();
 		Map<Bel, Cell> sitePlacementMap = placementMap.get(site);
 		sitePlacementMap.remove(cell.getBel());
 		if (sitePlacementMap.size() == 0)
 			placementMap.remove(site);
-		
+
+		// clear the location from the cell
 		cell.unplace();
-		
-		// undo all cell pin mappings (if they exists)
-		cell.getPins().forEach(CellPin::clearPinMappings);
 	}
 
 	/**
 	 * Unroutes the INTERSITE portions of all nets currently in the design.
 	 * This function is currently not recommended for use. Further testing is needed.
 	 */
-	@Deprecated
 	public void unrouteDesign() {
 		getNets().forEach(CellNet::unrouteIntersite);
 	}
@@ -684,7 +708,6 @@ public class CellDesign extends AbstractDesign {
 	 * Unroutes the INTERSITE portions of all nets currently in the design.
 	 * This function is currently not recommended for use. Further testing is needed.
 	 */
-	@Deprecated
 	public void unrouteDesignFull() {
 		getNets().forEach(CellNet::unrouteFull);
 		getCells().forEach(Cell::clearPinMappings);
@@ -695,20 +718,19 @@ public class CellDesign extends AbstractDesign {
 	 * mappings are undone as well. This function is currently not recommended for use.
 	 * Further testing is needed.   
 	 */
-	@Deprecated
 	public void unplaceDesign() {
 		unrouteDesign();
 
 		for (Cell cell : getCells()) {
 			if (cell.isMacro()) {
-				cell.getInternalCells().forEach(this::unplaceCell_impl);
+				cell.getInternalCells().forEach(this::_unplaceCell);
 			}
 			else {
-				this.unplaceCell_impl(cell);
+				this._unplaceCell(cell);
 			}
 		}
 	}
-	
+
 	/**
 	 * Set the INTRASITE routing of a {@link Site}. If you are modifying the logic within 
 	 * a {@link Site}, this function needs to be called before exporting a design. 

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryCell.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryCell.java
@@ -229,14 +229,7 @@ public abstract class LibraryCell implements Serializable {
 	 * for a library macro
 	 */
 	abstract public List<BelId> getPossibleAnchors();
-	/**
-	 * For macro cells, returns a list of required bel object that are
-	 * needed to place the macro. This functionality is currently unimplemented
-	 * and should not be used.
-	 * @param anchor Anchor {@link Bel} for the macro
-	 */
-	abstract public List<Bel> getRequiredBels(Bel anchor);
-	
+
 	/**
 	 * Returns a list of site properties that are shared across a {@link Bel} Type.
 	 * For example, all Flip Flop Bels in a Site, must all be either rising edge or

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryMacro.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryMacro.java
@@ -29,7 +29,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import edu.byu.ece.rapidSmith.design.NetType;
-import edu.byu.ece.rapidSmith.device.Bel;
 import edu.byu.ece.rapidSmith.device.BelId;
 
 /**
@@ -99,12 +98,6 @@ public class LibraryMacro extends LibraryCell {
 	@Override
 	public List<BelId> getPossibleAnchors() {
 		return null;
-	}
-
-	@Override
-	public List<Bel> getRequiredBels(Bel anchor) {
-		throw new UnsupportedOperationException("This functionality is not yet implemented.");
-
 	}
 
 	@Override
@@ -193,8 +186,7 @@ public class LibraryMacro extends LibraryCell {
 	 * Creates the internal cells of a macro cell instance. This function is package private
 	 * and is not for general use.  
 	 * 
-	 * @param parentName The string name of the parent macro cell. All cells that
-	 * 					are created from this function have the prefix "parentName/" 
+	 * @param parent The parent macro cell
 	 * @return A map containing the constructed cells
 	 */
 	Map<String, Cell> constructInternalCells(Cell parent) {

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/SimpleLibraryCell.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/SimpleLibraryCell.java
@@ -20,10 +20,8 @@
 
 package edu.byu.ece.rapidSmith.design.subsite;
 
-import edu.byu.ece.rapidSmith.device.Bel;
 import edu.byu.ece.rapidSmith.device.BelId;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -133,11 +131,6 @@ public class SimpleLibraryCell extends LibraryCell {
 	 */
 	public void setPossibleBels(List<BelId> possibleBels) {
 		this.compatibleBels = possibleBels;
-	}
-
-	@Override
-	public List<Bel> getRequiredBels(Bel anchor) {
-		return Collections.singletonList(anchor);
 	}
 
 	@Override

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/CreateDesignExample.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/CreateDesignExample.java
@@ -121,7 +121,7 @@ public class CreateDesignExample {
 		// 2. Find a BEL within that site to place the cell onto (you find the right BEL types for this by querying the Cell)
 		//    Get a set of BelId objects which describe the site type/belname pairs where this cell could be placed.
 		//    This will consist of pairs like: SLICEL/A6LUT or SLICEM/D6LUT
-		List<BelId> anchors = invcell.getPossibleAnchors();
+		List<BelId> anchors = invcell.getPossibleLocations();
 		//    Pull the actual site types out of these BelId objects and collect them into a sorted list without duplicates 
 		//    (the resulting list should contain just SLICEL and SLICEM)
 		List<SiteType> anchorsitetypes = anchors.stream()
@@ -135,7 +135,7 @@ public class CreateDesignExample {
 		slice = device.getAllSitesOfType(sitetype).get(0);
 		// Place the invcell on a suitable LUT (the first one found that is suitable)
 		// Get a list of the ones which have the primitive site type matching above (which will be SLICEL or SLICEM)
-		anchors = invcell.getPossibleAnchors().stream()
+		anchors = invcell.getPossibleLocations().stream()
 				.filter(t -> t.getSiteType() == sitetype)
 				.collect(Collectors.toList());
 		// Place the cell on the bel of the first one
@@ -145,7 +145,7 @@ public class CreateDesignExample {
 		// NOTE: in general it would be good to ensure the LUT and FF in are in corresponding BELS (an ALUT with an AFF, a BLUT with a BFF and so on) 
 		//       to ensure good packing and routability.
 		// But, in this case it doesn't really matter, the design will be routable.
-		anchors = ffcell.getPossibleAnchors().stream()
+		anchors = ffcell.getPossibleLocations().stream()
 				.filter(t -> t.getSiteType() == sitetype)
 				.collect(Collectors.toList());
 		design.placeCell(ffcell, slice.getBel(anchors.get(0).getName()));

--- a/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/DesignAnalyzer.java
@@ -84,9 +84,9 @@ public class DesignAnalyzer {
 				System.out.println("    Cell is macro");
 				continue;
 			}
-			if (c.getPossibleAnchors().size() == 0)
+			if (c.getPossibleLocations().size() == 0)
 				System.out.println("    This cell cannot be placed.");
-			for (BelId b : c.getPossibleAnchors()) {
+			for (BelId b : c.getPossibleLocations()) {
 				System.out.println("    Can be placed onto sites of type " + b.getSiteType() + " on Bels of type " + b.getName());
 			}
 		}
@@ -105,7 +105,7 @@ public class DesignAnalyzer {
 	 * Print out a formatted representation of a design to help visualize it.  Another way of visualizing designs is illustrated
 	 * in the DotFilePrinterDemo program in the examples2 directory.  
 	 * @param design The design to be pretty printed.
-	 * @param Flag to control printing of detailed cellBelPinMappings 
+	 * @param cellBelPinMappings to control printing of detailed cellBelPinMappings
 	 */
 	public static void prettyPrintDesign(CellDesign design, boolean cellBelPinMappings) {
 		// Print the cells

--- a/src/test/java/design/subsite/CellTest.java
+++ b/src/test/java/design/subsite/CellTest.java
@@ -198,7 +198,7 @@
      }
 
      @Test
-     @DisplayName("test Cell method 'getPossibleAnchors'")
+     @DisplayName("test Cell method 'getPossibleLocations'")
      public void testGetPossibleAnchors() {
          verifyAnchors(lutcell, Arrays.asList("SLICEL-D6", "SLICEL-D5", "SLICEL-C6", "SLICEL-C5", "SLICEL-B6", "SLICEL-B5", "SLICEL-A5", "SLICEL-A6", "SLICEM-D6", "SLICEM-D5", "SLICEM-C6", "SLICEM-C5", "SLICEM-B6", "SLICEM-B5", "SLICEM-A5", "SLICEM-A6"));
          verifyAnchors(iportcell, Arrays.asList("IOB33-PAD", "IOB33S-PAD", "IOB33M-PAD", "IPAD-PAD"));
@@ -214,7 +214,7 @@
       * expected the list of possible anchors to check for
       */
      private void verifyAnchors(Cell cell, List<String> expected) {
-         List<String> actual = cell.getPossibleAnchors().stream()
+         List<String> actual = cell.getPossibleLocations().stream()
                  .map(belid -> (belid.getSiteType()+"-"+belid.getName()).replace("ARTIX7.", "").replace("LUT", ""))
                  .collect(Collectors.toList());
          assertEquals(expected.size(), actual.size(), "Expected anchor count for " + cell.getName() + " doesn't match calculated.");
@@ -229,7 +229,7 @@
          // test each of the sample test cells
          for (Cell cell : testcells) {
              // Attempt to place and remove the cell on each type of anchor
-             for (BelId anchortype : cell.getPossibleAnchors()) {
+             for (BelId anchortype : cell.getPossibleLocations()) {
                  // Create a new empty CellDesign for the designated FPGA part
                  CellDesign design = new CellDesign("CellPlacementTest", "xc7a100tcsg324");
                  // Add the cell to the design


### PR DESCRIPTION
Provides a new placeCellSafe method that checks that the BEL the cell being placed onto has the same type as other BELs being used in the site.  This will help some with a frequent complaint about bugs popping up from mismatched site types.
Cleans up some of the cell placement code that was handling hierarchical cells with fixed placement structures.  Our adopted macro approach does not use this capability so I have removed it to speed up and simplify the code.
Renamed a few parameter names to remove the concept of anchor (we're not really anchoring cells with our macro approach)
Deprecated getPossibleAnchors method for getPossibleLocations
