### PR TITLE
Updated Site::setType to check the allowed site types

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/device/Device.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Device.java
@@ -659,7 +659,7 @@ public class Device implements Serializable {
 	 */
 	private void setSiteTypes() {
 		for (Site site : sites.values()) {
-			site.setType(site.getPossibleTypes()[0]);
+			site.setTypeUnchecked(site.getPossibleTypes()[0]);
 		}
 	}
 

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
@@ -19,6 +19,8 @@
  */
 package edu.byu.ece.rapidSmith.device;
 
+import edu.byu.ece.rapidSmith.util.Exceptions;
+
 import java.io.Serializable;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -168,14 +170,23 @@ public final class Site implements Serializable{
 
 	/**
 	 * Updates the type of this site to the specified type.
-	 * Does not perform any validation, so this site can mistakenly be given a
-	 * type that is not in its possible types set.
-	 * <p>
+	 * <p/>
 	 * This method obtains the site template from its device, therefore, the
 	 * site must already exist in a tile which exists in a device.
 	 * @param type the new type for this site
 	 */
 	public void setType(SiteType type) {
+		if (!Arrays.asList(getPossibleTypes()).contains(type))
+			throw new IllegalArgumentException("Invalid type: site=" + name + ", type=" + type);
+		template = getTile().getDevice().getSiteTemplate(type);
+	}
+
+	/**
+	 * Same as {@link #setType(SiteType)} except does not validate that the type is a
+	 * legal type.
+	 * @param type the new type for this site
+	 */
+	public void setTypeUnchecked(SiteType type) {
 		template = getTile().getDevice().getSiteTemplate(type);
 	}
 

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/ise/XDLReader.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/ise/XDLReader.java
@@ -124,7 +124,7 @@ public final class XDLReader {
 			} else {
 				assert ctx.PLACED() != null;
 				String siteName = ctx.site.getText();
-				Site site = device.getSite(siteName); // TODO rename getPrimtiveSite to getSite
+				Site site = device.getSite(siteName);
 				if (site == null)
 					throw new ParseException("no such site on device: " + siteName);
 				// TODO add check against tile

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
@@ -111,8 +111,7 @@ public class XdcPlacementInterface {
 		Cell cell = tryGetCell(toks[1]);
 		Site site = tryGetSite(toks[2]);
 		
-		// TODO: add a check to see that the sitetype is a valid option for the site
-		String siteType = toks[3]; 
+		String siteType = toks[3];
 		site.setType(SiteType.valueOf(device.getFamily(), siteType));
 		
 		Bel bel = tryGetBel(site, toks[4]);

--- a/src/test/java/design/subsite/RouteTreeTest.java
+++ b/src/test/java/design/subsite/RouteTreeTest.java
@@ -123,7 +123,7 @@ class RouteTreeTest {
 	private static void makeDummySite(Site dummySite, SiteType dummySiteType) {
 		dummySite.setName("dummy_site");
 		dummySite.setIndex(0);
-		dummySite.setType(dummySiteType);
+		dummySite.setTypeUnchecked(dummySiteType);
 		dummySite.setPossibleTypes(new SiteType[] {dummySiteType});
 
 		SiteTemplate siteTemplate = device.getSiteTemplate(dummySiteType);


### PR DESCRIPTION
and throws an error if the types don't match.

In lieu of the potential slow down, I added a new setTypeUnchecked method
which will forgo the check.  I was going to update the setType calls in
the tcp reader, but a TODO task already existed for checking the type
to ensure it is valid, so I left the check in.

I don't foresee a big slow down since this is not a commonly used method
in most situations the size of the list are normally no more than 2-3
elements large.