### PR TITLE
Fix Github Project Language Stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
-*.rb linguist-language=Java
+*.rsc linguist-language=RapidSmithCheckpoint
+*.tcp linguist-language=TclCheckpoint
+*.dcp linguist-language=DesignCheckpoint
+*.dat linguist-language=SerializedDevice
+
+docs/* linguist-documentation


### PR DESCRIPTION
Fixes the Project Language Stats on GitHub.  Right now, GitHub currently lists RS2 as being a Rascal-dominate project (due to all of the .rsc checkpoint files which it interprets as Rascal files).  This correctly identifies those files as not data files and fixes the statistics.  This change fixes that stats and makes GitHub report RS2 as a Java-based project.

See github.com/trharoldsen/RapidSmith2-public/ for reference.