### PR TITLE
Fixed instanceX and instanceY variables to be deserialized correctly

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
@@ -841,6 +841,8 @@ public final class Site implements Serializable{
 		repl.possibleTypes = possibleTypes;
 		repl.externalWires = externalWires;
 		repl.bondedType = bondedType;
+		repl.instanceX = instanceX;
+		repl.instanceY = instanceY;
 		return repl;
 	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
@@ -65,8 +65,8 @@ public final class Site implements Serializable{
 	public Site(){
 		name = null;
 		tile = null;
-		instanceX = null;
-		instanceY = null;
+		instanceX = -1;
+		instanceY = -1;
 	}
 	
 	/**
@@ -123,7 +123,7 @@ public final class Site implements Serializable{
 	 * @return the X integer value of the site name or -1 if this instance is
 	 * not placed or does not have X/Y coordinates in the site name
 	 */
-	public Integer getInstanceX(){
+	public int getInstanceX(){
 		return instanceX;
 	}
 
@@ -133,7 +133,7 @@ public final class Site implements Serializable{
 	 * @return The Y integer value of the site name or -1 if this instance is
 	 * not placed or does not have X/Y coordinates in the site name
 	 */
-	public Integer getInstanceY(){
+	public int getInstanceY(){
 		return instanceY;
 	}
 	
@@ -143,8 +143,8 @@ public final class Site implements Serializable{
 	 */
 	public boolean parseCoordinatesFromName(String name) {
 		// reset the values
-		this.instanceX = null;
-		this.instanceY = null;
+		this.instanceX = -1;
+		this.instanceY = -1;
 
 		// match the values
 		Pattern re = Pattern.compile(".+_X(\\d+)Y(\\d+)");

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
@@ -19,8 +19,6 @@
  */
 package edu.byu.ece.rapidSmith.device;
 
-import edu.byu.ece.rapidSmith.util.Exceptions;
-
 import java.io.Serializable;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -816,6 +814,8 @@ public final class Site implements Serializable{
 		private SiteType[] possibleTypes;
 		private Map<SiteType, Map<String, Integer>> externalWires;
 		private BondedType bondedType;
+		private int instanceX;
+		private int instanceY;
 
 		@SuppressWarnings("unused")
 		private Site readResolve() {
@@ -824,6 +824,12 @@ public final class Site implements Serializable{
 			site.possibleTypes = possibleTypes;
 			site.externalWires = externalWires;
 			site.bondedType = bondedType;
+			
+			if (instanceX != 0 || instanceY != 0 || !site.parseCoordinatesFromName(name)) { 
+				site.instanceX = (instanceX != 0) ? instanceX : -1; 
+				site.instanceY = (instanceX != 0) ? instanceX : -1; 
+			}
+			
 			return site;
 		}
 	}

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
@@ -123,7 +123,7 @@ public final class Site implements Serializable{
 	 * @return the X integer value of the site name or -1 if this instance is
 	 * not placed or does not have X/Y coordinates in the site name
 	 */
-	public int getInstanceX(){
+	public Integer getInstanceX(){
 		return instanceX;
 	}
 
@@ -133,7 +133,7 @@ public final class Site implements Serializable{
 	 * @return The Y integer value of the site name or -1 if this instance is
 	 * not placed or does not have X/Y coordinates in the site name
 	 */
-	public int getInstanceY(){
+	public Integer getInstanceY(){
 		return instanceY;
 	}
 	

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Site.java
@@ -39,9 +39,9 @@ public final class Site implements Serializable{
 	/** The tile where this site resides */
 	private Tile tile;
 	/** The X coordinate of the instance (ex: SLICE_X#Y5) */
-	private int instanceX;
+	private Integer instanceX;
 	/** The Y coordinate of the instance (ex: SLICE_X5Y#) */
-	private int instanceY;
+	private Integer instanceY;
 	/** The bondedness of the site */
 	private BondedType bondedType;
 	/** Stores the template of the type that has been assigned to this site. */
@@ -65,8 +65,8 @@ public final class Site implements Serializable{
 	public Site(){
 		name = null;
 		tile = null;
-		instanceX = -1;
-		instanceY = -1;
+		instanceX = null;
+		instanceY = null;
 	}
 	
 	/**
@@ -143,8 +143,8 @@ public final class Site implements Serializable{
 	 */
 	public boolean parseCoordinatesFromName(String name) {
 		// reset the values
-		this.instanceX = -1;
-		this.instanceY = -1;
+		this.instanceX = null;
+		this.instanceY = null;
 
 		// match the values
 		Pattern re = Pattern.compile(".+_X(\\d+)Y(\\d+)");
@@ -814,8 +814,8 @@ public final class Site implements Serializable{
 		private SiteType[] possibleTypes;
 		private Map<SiteType, Map<String, Integer>> externalWires;
 		private BondedType bondedType;
-		private int instanceX;
-		private int instanceY;
+		private Integer instanceX;
+		private Integer instanceY;
 
 		@SuppressWarnings("unused")
 		private Site readResolve() {
@@ -825,9 +825,9 @@ public final class Site implements Serializable{
 			site.externalWires = externalWires;
 			site.bondedType = bondedType;
 			
-			if (instanceX != 0 || instanceY != 0 || !site.parseCoordinatesFromName(name)) { 
-				site.instanceX = (instanceX != 0) ? instanceX : -1; 
-				site.instanceY = (instanceX != 0) ? instanceX : -1; 
+			if (instanceX != null || instanceY != null || !site.parseCoordinatesFromName(name)) {
+				site.instanceX = (instanceX != null) ? instanceX : -1;
+				site.instanceY = (instanceY != null) ? instanceY : -1;
 			}
 			
 			return site;

--- a/src/test/kotlin/edu/byu/ece/rapidSmith/device/SiteNameTests.kt
+++ b/src/test/kotlin/edu/byu/ece/rapidSmith/device/SiteNameTests.kt
@@ -24,8 +24,8 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICEX5Y201")
 		assertFalse(ret)
-		assertEquals(-1, site.instanceX)
-		assertEquals(-1, site.instanceY)
+		assertNull(site.instanceX)
+		assertNull(site.instanceY)
 	}
 
 	@Test
@@ -34,8 +34,8 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICE_Y201")
 		assertFalse(ret)
-		assertEquals(-1, site.instanceX)
-		assertEquals(-1, site.instanceY)
+		assertNull(site.instanceX)
+		assertNull(site.instanceY)
 	}
 
 	@Test
@@ -44,8 +44,8 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICE_X201")
 		assertFalse(ret)
-		assertEquals(-1, site.instanceX)
-		assertEquals(-1, site.instanceY)
+		assertNull(site.instanceX)
+		assertNull(site.instanceY)
 	}
 
 	@Test
@@ -54,8 +54,8 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICE_XY201")
 		assertFalse(ret)
-		assertEquals(-1, site.instanceX)
-		assertEquals(-1, site.instanceY)
+		assertNull(site.instanceX)
+		assertNull(site.instanceY)
 	}
 
 	@Test
@@ -64,7 +64,7 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICE_X201Y")
 		assertFalse(ret)
-		assertEquals(-1, site.instanceX)
-		assertEquals(-1, site.instanceY)
+		assertNull(site.instanceX)
+		assertNull(site.instanceY)
 	}
 }

--- a/src/test/kotlin/edu/byu/ece/rapidSmith/device/SiteNameTests.kt
+++ b/src/test/kotlin/edu/byu/ece/rapidSmith/device/SiteNameTests.kt
@@ -1,11 +1,9 @@
 package edu.byu.ece.rapidSmith.device
 
 import edu.byu.ece.rapidSmith.RSEnvironment
-import edu.byu.ece.rapidSmith.util.Exceptions
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import java.io.IOException
 
 /**
  * Tests for parsing the XY coordinates from a site name.
@@ -14,7 +12,6 @@ class SiteNameTests {
 
 	@Test
 	@DisplayName("Site coordinates are deserialized correctly")
-	@Throws(IOException::class)
 	fun deserializeNames() {
 		// Test that Artix device site coordinates match those expected by the name
 		val dev = RSEnvironment.defaultEnv().getDevice("xc7a100tcsg324")

--- a/src/test/kotlin/edu/byu/ece/rapidSmith/device/SiteNameTests.kt
+++ b/src/test/kotlin/edu/byu/ece/rapidSmith/device/SiteNameTests.kt
@@ -1,13 +1,28 @@
 package edu.byu.ece.rapidSmith.device
 
+import edu.byu.ece.rapidSmith.RSEnvironment
+import edu.byu.ece.rapidSmith.util.Exceptions
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import java.io.IOException
 
 /**
  * Tests for parsing the XY coordinates from a site name.
  */
 class SiteNameTests {
+
+	@Test
+	@DisplayName("Site coordinates are deserialized correctly")
+	@Throws(IOException::class)
+	fun deserializeNames() {
+		// Test that Artix device site coordinates match those expected by the name
+		val dev = RSEnvironment.defaultEnv().getDevice("xc7a100tcsg324")
+		val xySite = dev.getSite("SLICE_X31Y102")
+		assertEquals(31, xySite.instanceX)
+		assertEquals(102, xySite.instanceY)
+	}
+
 	@Test
 	@DisplayName("parseCoordinatesFromName parses indices from site name")
 	fun simpleWorking() {
@@ -24,8 +39,8 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICEX5Y201")
 		assertFalse(ret)
-		assertNull(site.instanceX)
-		assertNull(site.instanceY)
+		assertEquals(-1, site.instanceX)
+		assertEquals(-1, site.instanceY)
 	}
 
 	@Test
@@ -34,8 +49,8 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICE_Y201")
 		assertFalse(ret)
-		assertNull(site.instanceX)
-		assertNull(site.instanceY)
+		assertEquals(-1, site.instanceX)
+		assertEquals(-1, site.instanceY)
 	}
 
 	@Test
@@ -44,8 +59,8 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICE_X201")
 		assertFalse(ret)
-		assertNull(site.instanceX)
-		assertNull(site.instanceY)
+		assertEquals(-1, site.instanceX)
+		assertEquals(-1, site.instanceY)
 	}
 
 	@Test
@@ -54,8 +69,8 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICE_XY201")
 		assertFalse(ret)
-		assertNull(site.instanceX)
-		assertNull(site.instanceY)
+		assertEquals(-1, site.instanceX)
+		assertEquals(-1, site.instanceY)
 	}
 
 	@Test
@@ -64,7 +79,7 @@ class SiteNameTests {
 		val site = Site()
 		val ret = site.parseCoordinatesFromName("SLICE_X201Y")
 		assertFalse(ret)
-		assertNull(site.instanceX)
-		assertNull(site.instanceY)
+		assertEquals(-1, site.instanceX)
+		assertEquals(-1, site.instanceY)
 	}
 }


### PR DESCRIPTION
See issue #325. @trharoldsen was right - the instanceX and instanceY variables weren't being deserialized correctly. This PR fixes that.