### PR TITLE
V1.1.0 Release

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,10 +1,8 @@
-## Release v2.0.0
-
-### Major Changes:
-* Removed BelPin::getSitePins methods. (#260, #319)
+## Release v1.1.0
 
 ### Minor Changes:
 * Updated Site::setType to check the allowed site types and throw an error if the types don't match. Also added Site::setTypeUnchecked to forgo the check and avoid potential slowdown. (#321)
+* Removed BelPin::getSitePins methods. (#260, #319)
 
 ### Patches / Bug Fixes:
 * After merging static nets in the edif import process, macro pins now point to the corresponding global VCC or global GND net. (#317, #320)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,15 @@
+## Release v2.0.0
+
+### Major Changes:
+* Removed BelPin::getSitePins methods. (#260, #319)
+
+### Minor Changes:
+* Updated Site::setType to check the allowed site types and throw an error if the types don't match. Also added Site::setTypeUnchecked to forgo the check and avoid potential slowdown. (#321)
+
+### Patches / Bug Fixes:
+* After merging static nets in the edif import process, macro pins now point to the corresponding global VCC or global GND net. (#317, #320)
+* Fixed Github project language stats to report RapidSmith2 as a Java-based project. (#324)
+
 ## Release v1.0.0
 
 This is the first GA (General Availability) release of RapidSmith2 and the API can now be considered stable. 


### PR DESCRIPTION
See #327. While renaming my branch, I inadvertently deleted it, closing the original PR.

I just revised the release notes to be v1.1.0 instead of v2.0.0. Also updated 
[the Github Release draft.](https://github.com/byuccl/RapidSmith2/releases/tag/untagged-948254dd58febd17cc3c)

The release notes record all PRs made since the last release, but not any of the PRs currently waiting to be approved and merged.
  