### PR TITLE
Added CIN as possible BEL pin for CARRY4.CI pins.

### DIFF
--- a/devices/artix7/cellLibrary.xml
+++ b/devices/artix7/cellLibrary.xml
@@ -1119,6 +1119,7 @@
             <pin>
               <name>CI</name>
               <possible>CYINIT</possible>
+              <possible>CIN</possible>
             </pin>
             <pin>
               <name>DI[3]</name>
@@ -1199,6 +1200,7 @@
             <pin>
               <name>CI</name>
               <possible>CYINIT</possible>
+              <possible>CIN</possible>
             </pin>
             <pin>
               <name>DI[3]</name>


### PR DESCRIPTION
Added CIN as possible BEL pin for CARRY4.CI pins.  Needed for packer to work correctly.
