### PR TITLE
Support for RAMB36E1 and FIF036E1 dynamic pin mappings

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/examples/CreateDynamicPinMappings.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/examples/CreateDynamicPinMappings.java
@@ -42,7 +42,7 @@ public class CreateDynamicPinMappings {
 					System.out.println("    Once it is done, re-run this program and it should be found in the cache.");
     				List<String> res = PinMapping.createPinMappings( 
     						c, 
-    						c.getBel().getName(), 
+    						c.getBel().getFullName(),
     						true);
 					
 				}


### PR DESCRIPTION
As specified in #355, when trying to obtain the pin mapping for RAMB36E1 and FIFO36E1 type cells, the current solution failed as RAMB36E1 and FIF0E6E1 BELs are hidden behind alternative site types.  This solution changes the approach to accepting the entire name of a BEL and using that to place the test cell to determine the pin mappings.  

I have also added support for updating the pin mappings using the tile type, site index and name of the BEL of interest.  This was needed for the packer as I am not working with a properly loaded device and do not have actual site locations to work with.