### PR TITLE
Edif Interface: handle bus ports with multiple sets of brackets

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
@@ -161,12 +161,12 @@ public final class EdifInterface {
 
 			int offset = 0;
 			
-			// find the port suffix and offset
-			String portSuffix = port.getOldName();
+			// find the port prefix and offset
+			String portPrefix = port.getOldName();
 			if (port.isBus()) {
 				Matcher matcher = busNamePattern.matcher(port.getOldName());
 				if (matcher.matches()) {
-					portSuffix = matcher.group(1);
+					portPrefix = matcher.group(1);
 					offset = Integer.parseInt(matcher.group(2));
 					portOffsetMap.put(port, offset);
 				}
@@ -181,10 +181,9 @@ public final class EdifInterface {
 				LibraryCell libCell = libCells.get(libraryPortType);
 				
 				String portName = port.isBus() ?
-									String.format("%s[%d]", portSuffix, reverseBusIndex(port.getWidth(), busMember.bitPosition(), offset)) :
-									portSuffix;
+									String.format("%s[%d]", portPrefix, reverseBusIndex(port.getWidth(), busMember.bitPosition(), offset)) :
+									portPrefix;
 				Cell portCell = new Cell(portName, libCell);
-				//portCell.getProperties().update(new Property("Dir", PropertyType.USER, PortDirection.getPortDirectionForImport(portCell)));
 				design.addCell(portCell);
 			}
 		}
@@ -321,7 +320,7 @@ public final class EdifInterface {
 			if (portRef.isTopLevelPortRef()) {
 								
 				String portname = portRef.isSingleBitPortRef() ? port.getOldName() : 
-				 				  String.format("%s[%d]", getPortNameSuffix(port.getName()), reverseBusIndex(port.getWidth(), portRef.getBusMember(), portOffsetMap.get(port)));
+				 				  String.format("%s[%d]", getPortNamePrefix(port.getOldName()), reverseBusIndex(port.getWidth(), portRef.getBusMember(), portOffsetMap.get(port)));
 				
 				Cell portCell = design.getCell(portname);
 				
@@ -361,10 +360,6 @@ public final class EdifInterface {
 				net.setType(NetType.GND);
 			}
 			
-			//if (net.getName().equals("vga_o[76]")) {
-			//	System.out.println(" --> " + pinname  + " " + node.getPin(pinname) + " " + node.isMacro());
-			//}
-			
 			net.connectToPin(node.getPin(pinname));						
 		}		
 	}
@@ -373,9 +368,9 @@ public final class EdifInterface {
 	 * Vivado ports that are buses are named portName[15:0]
 	 * This function will return the "portName" portion of the bus name
 	 */
-	private static String getPortNameSuffix(String portName) {
+	private static String getPortNamePrefix(String portName) {
 		
-		int bracketIndex = portName.indexOf("[");
+		int bracketIndex = portName.lastIndexOf("[");
 		return bracketIndex == -1 ? portName : portName.substring(0, bracketIndex);
 	}
 		
@@ -571,7 +566,6 @@ public final class EdifInterface {
 		
 		// create the cell instances
 		Iterator<Cell> cellIt = design.getLeafCells().iterator();
-		//for (Cell cell : design.getCells) {
 		while (cellIt.hasNext()) {
 			Cell cell = cellIt.next();
 			
@@ -638,7 +632,9 @@ public final class EdifInterface {
 						createEdifNameable(portName);
 			}
 			else {
-				edifPortName = new RenamedObject(portName, String.format("%s[%d:%d]", portName, portInfo.getMax(), portInfo.getMin()));
+				// Some bus ports have bad names like port[0:0][7:0].
+				// Because of this, just always make sure the new name is Edif Nameable
+				edifPortName = new RenamedObject(createEdifNameable(portName), String.format("%s[%d:%d]", portName, portInfo.getMax(), portInfo.getMin()));
 			}
 						
 			cellInterface.addPort(edifPortName, portInfo.getWidth(), portInfo.getDirection());
@@ -690,15 +686,15 @@ public final class EdifInterface {
 	 * Creates a port reference (connection) for an EDIF net from a top-level port cell.
 	 */
 	private static EdifPortRef createEdifPortRefFromPort(Cell port, EdifCell edifParent, EdifNet edifNet, int portOffset) {
-		
-		String[] toks = port.getName().split("\\[");
+		// Split on the last '['
+		String[] toks = port.getName().split("\\[(?!.*\\[)");
 		
 		assert(toks.length == 1 || toks.length == 2);
-		
+
 		EdifPort edifPort = edifParent.getPort(toks[0]);
 		
 		if (edifPort == null) {
-			edifPort = edifParent.getPort(createEdifNameable(port.getName()).getName());
+			edifPort = edifParent.getPort(getEdifName(toks[0]));
 		}
 		
 		int portIndex = 1;


### PR DESCRIPTION
Issue #358 provided an example where an EDIF netlist contains bus ports with multiple sets of brackets. An example of what this looks like in an .edf is:
`(port (array (rename ciphertext_o_0_0_ "ciphertext_o[0,0][7:0]") 8) (direction OUTPUT))`

The EDIF interface wasn't prepared for this case. This PR fixes this (and deletes some old commented out code). I've tested this with all the example designs, some other larger designs, and the design in #358. 