### PR TITLE
Create EDIF RPMs for LUTRAM macros

### DIFF
--- a/devices/artix7/cellLibrary.xml
+++ b/devices/artix7/cellLibrary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2016 Brigham Young University
+ ~ Copyright (c) 2019 Brigham Young University
  ~ 
  ~ This file is part of the BYU RapidSmith Tools.
 
@@ -67466,6 +67466,31 @@
                 <type>IBUFDS</type>
             </internal>
         </cells>
+        <rpms>
+            <rpm>
+              <type>IOB33M</type>
+              <internal>
+                <name>IBUFDS</name>
+                <bel>
+                  <id>
+                    <site_type>IOB33M</site_type>
+                    <name>INBUF_EN</name>
+                  </id>
+                </bel>
+                <rloc>X0Y0</rloc>
+              </internal>
+              <internal>
+                <name>IBUFDS_0</name>
+                <bel>
+                  <id>
+                    <site_type>IOB33S</site_type>
+                    <name>INBUF_EN</name>
+                  </id>
+                </bel>
+                <rloc>X0Y1</rloc>
+              </internal>
+            </rpm>
+        </rpms>
         <pins>
             <pin>
                 <name>O</name>

--- a/devices/zynq/cellLibrary.xml
+++ b/devices/zynq/cellLibrary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2016 Brigham Young University
+ ~ Copyright (c) 2019 Brigham Young University
  ~ 
  ~ This file is part of the BYU RapidSmith Tools.
 
@@ -99223,6 +99223,31 @@
                 <type>IBUFDS</type>
             </internal>
         </cells>
+        <rpms>
+            <rpm>
+              <type>IOB33M</type>
+              <internal>
+                <name>IBUFDS</name>
+                <bel>
+                  <id>
+                    <site_type>IOB33M</site_type>
+                    <name>INBUF_EN</name>
+                  </id>
+                </bel>
+                <rloc>X0Y0</rloc>
+              </internal>
+              <internal>
+                <name>IBUFDS_0</name>
+                <bel>
+                  <id>
+                    <site_type>IOB33S</site_type>
+                    <name>INBUF_EN</name>
+                  </id>
+                </bel>
+                <rloc>X0Y1</rloc>
+              </internal>
+            </rpm>
+        </rpms>
         <pins>
             <pin>
                 <name>O</name>

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
@@ -268,6 +268,7 @@ public class CellLibrary implements Iterable<LibraryCell> {
 		LibraryMacro macroCell = new LibraryMacro(type);
 
 		loadInternalCellsFromXml(macroEl, macroCell);
+		loadRpmsFromXml(macroEl, macroCell);
 		loadPinsFromXml(macroEl, macroCell);
 		loadInternalNetsFromXml(macroEl, macroCell);
 		add(macroCell);
@@ -310,6 +311,26 @@ public class CellLibrary implements Iterable<LibraryCell> {
 			}
 		}
 		libCell.setLibraryPins(pins);
+	}
+
+	private void loadRpmsFromXml(Element macroEl, LibraryMacro macroCell) {
+		Element rpmsEl = macroEl.getChild("rpms");
+
+		for (Element rpmEl : rpmsEl.getChildren("rpm")) {
+			SiteType macroSiteType = SiteType.valueOf(familyType, rpmEl.getChildText("type"));
+			for (Element internalEl : rpmEl.getChildren("internal")) {
+				String internalCellName = internalEl.getChildText("name");
+				Element belEl = internalEl.getChild("bel");
+				Element id = belEl.getChild("id");
+				String site_type = id.getChildText("site_type");
+				BelId belId = new BelId(
+						SiteType.valueOf(familyType, site_type),
+						id.getChildText("name")
+				);
+				String rloc = internalEl.getChildText("rloc");
+				macroCell.addRpmCellEntry(macroSiteType, internalCellName, belId, rloc);
+			}
+		}
 	}
 	
 	private void loadInternalCellsFromXml(Element macroEl, LibraryMacro macroCell) {

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryCell.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryCell.java
@@ -220,7 +220,10 @@ public abstract class LibraryCell implements Serializable {
 	 * Returns {@code true} if the cell is a latch cell (LDCE, LDPE, etc.), {@code false} otherwise.
 	 */
 	abstract public boolean isLatch();
-
+	/**
+	 * Returns {@code true} if the cell is a LUT RAM macro cell, {@code false} otherwise.
+	 */
+	abstract public boolean isLutRamMacro();
 	/**
 	 * Returns {@code true} if the cell represents a top-level port cell.
 	 */

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryMacro.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryMacro.java
@@ -30,6 +30,8 @@ import java.util.regex.Pattern;
 
 import edu.byu.ece.rapidSmith.design.NetType;
 import edu.byu.ece.rapidSmith.device.BelId;
+import edu.byu.ece.rapidSmith.device.SiteType;
+import edu.byu.ece.rapidSmith.util.Exceptions;
 
 /**
  * Represents a primitive MACRO cell from Vivado cell library. A macro library 
@@ -41,15 +43,18 @@ public class LibraryMacro extends LibraryCell {
 	private static final long serialVersionUID = 282290704449047358L;
 
 	private Map<LibraryPin, List<InternalPin>> pinMap;
-	private Map<String, String> internalToExternalPinMap;	
-	private List<InternalCell> internalCells;
+	private Map<String, String> internalToExternalPinMap;
+	private Map<String, InternalCell> internalCells;
 	private List<InternalNet> internalNets;
 	private Map<String, Integer> pinOffsetMap;
+	private static Map<SiteType, RPM> rpmsMap;
 	private static Pattern pinNamePattern;
+	private static Pattern lutramPattern;
 	
 	static 
 	{
 		pinNamePattern = Pattern.compile("(.+)/([^/]+)$");
+		lutramPattern = Pattern.compile("RAM[^B].*");
 	}
 	
 	
@@ -62,7 +67,8 @@ public class LibraryMacro extends LibraryCell {
 		super(name);
 		pinMap = new HashMap<>();
 		internalToExternalPinMap = new HashMap<>();
-		internalCells = new ArrayList<>();
+		internalCells = new HashMap<>();
+		rpmsMap = new HashMap<>();
 	}
 
 	@Override
@@ -85,6 +91,14 @@ public class LibraryMacro extends LibraryCell {
 		return false;
 	}
 
+	/**
+	 * Returns {@code true} if the cell is a LUT RAM macro cell, {@code false} otherwise.
+	 */
+	@Override
+	public boolean isLutRamMacro() {
+		Matcher m = lutramPattern.matcher(this.getName());
+		return m.matches();
+	}
 
 	@Override
 	public boolean isVccSource() {
@@ -156,7 +170,25 @@ public class LibraryMacro extends LibraryCell {
 	 * @param libCell Internal cell type 
 	 */
 	void addInternalCell(String name, SimpleLibraryCell libCell) {
-		this.internalCells.add(new InternalCell(name, libCell));
+		this.internalCells.put(name, new InternalCell(name, libCell));
+	}
+
+	/**
+	 * Adds an entry for an internal cell to the RPM map.
+	 * @param siteType the site type of the particular RPM
+	 * @param internalCellName name of the internal cell
+	 * @param belId the belID the internal cell can be placed on for the RPM
+	 * @param rloc the RLOC of the internal cell for the RPM
+	 */
+	void addRpmCellEntry(SiteType siteType, String internalCellName, BelId belId, String rloc) {
+		RPM rpm = rpmsMap.computeIfAbsent(siteType, s -> new RPM(siteType));
+		InternalCell internalCell = internalCells.get(internalCellName);
+		if (internalCell == null) {
+			throw new Exceptions.ParseException("Internal Cell referenced in macro RPM xml \"" + internalCellName +
+					"\" not found \"");
+		}
+
+		rpm.addCellEntry(internalCell, belId, rloc);
 	}
 	
 	/**
@@ -192,6 +224,28 @@ public class LibraryMacro extends LibraryCell {
 		
 		return macroCell.getPin(internalToExternalPinMap.get(relativePinName));		
 	}
+
+	/**
+	 * Adds RPM EDIF properties to an internal cell. Currently only works for LUTRAM internal cells.
+	 * @param internalCell the internal cell to add the RPM properties to.
+	 * @param cell the cell instance of the internal cell
+	 */
+	private void addInternalCellRPMProperties(InternalCell internalCell, Cell cell) {
+		// Get site type to RPM map
+		// There is only one site type a LUT RAM can be placed on, so grab the first one
+		RPM rpm = rpmsMap.values().iterator().next();
+		BelIdRlocPair belIdRlocPair = rpm.getCellToBelRlocMap().get(internalCell);
+
+		// Add a U_SET property for the internal cell
+		cell.getProperties().update("U_SET", PropertyType.EDIF, cell.getParent().getName());
+
+		// Add the BEL constraint. Internal cells BEL constraints cannot change and need to be in place
+		// to ensure Vivado can place the macro (at least in the case of LUT RAMs).
+		cell.getProperties().update("BEL", PropertyType.EDIF, belIdRlocPair.getBelId().getName());
+
+		// Set the RLOC property
+		cell.getProperties().update("RLOC", PropertyType.EDIF, belIdRlocPair.getRloc());
+	}
 	
 	/**
 	 * Creates the internal cells of a macro cell instance. This function is package private
@@ -201,16 +255,22 @@ public class LibraryMacro extends LibraryCell {
 	 * @return A map containing the constructed cells
 	 */
 	Map<String, Cell> constructInternalCells(Cell parent) {
-		
 		Map<String, Cell> internalCellMap = new HashMap<>();
-		
 		String parentName = parent.getName();
 		
-		for (InternalCell internalCell : internalCells) {
+		for (InternalCell internalCell : internalCells.values()) {
 			String fullCellName = parentName + "/" + internalCell.getName();
 			Cell cell = new Cell(fullCellName, internalCell.getLeafCell());
 			cell.setParent(parent);
 			internalCellMap.put(fullCellName, cell);
+
+			// For now, only add an RPM for LUTRAM macros. LUTRAM macros can only be placed in one exact way
+			// (on a SLICEM), whereas other macros have more than one possible type of placement
+			// (see the IOBUF macro for an example). Additionally, only LUTRAM macros seem to need to have RPMs in
+			// place for Vivado to create the correct placer macros when it reads the EDIF.
+			if (parent.getLibCell().isLutRamMacro()) {
+				addInternalCellRPMProperties(internalCell, cell);
+			}
 		}
 		
 		return internalCellMap;	
@@ -384,4 +444,51 @@ public class LibraryMacro extends LibraryCell {
 			return pinName;
 		}
 	}
+
+	/**
+	 * A Bel ID and RLOC pair.
+	 */
+	private class BelIdRlocPair {
+		private final BelId belId;
+		private final String rloc;
+
+		public BelIdRlocPair(BelId belId, String rloc) {
+			this.belId = belId;
+			this.rloc = rloc;
+		}
+
+		public BelId getBelId() {
+			return belId;
+		}
+
+		public String getRloc() {
+			return rloc;
+		}
+
+	}
+
+	/**
+	 * An RPM for a library macro. There may be multiple RPMs for a given library macro.
+	 */
+	private class RPM {
+		/** The site type the whole macro is placed on for this RPM. Used as an identifier **/
+		private SiteType siteType;
+
+		public Map<InternalCell, BelIdRlocPair> getCellToBelRlocMap() {
+			return cellToBelRlocMap;
+		}
+
+		private Map<InternalCell, BelIdRlocPair> cellToBelRlocMap;
+
+		public RPM(SiteType siteType) {
+			this.siteType = siteType;
+			this.cellToBelRlocMap = new HashMap<>();
+		}
+
+		public void addCellEntry(InternalCell internalCell, BelId belId, String rloc) {
+			cellToBelRlocMap.put(internalCell, new BelIdRlocPair(belId, rloc));
+		}
+
+	}
+
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/SimpleLibraryCell.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/SimpleLibraryCell.java
@@ -127,6 +127,14 @@ public class SimpleLibraryCell extends LibraryCell {
 	}
 
 	/**
+	 * Returns {@code true} if the cell is a LUT RAM macro cell, {@code false} otherwise.
+	 */
+	@Override
+	public boolean isLutRamMacro() {
+		return false;
+	}
+
+	/**
 	 * Returns {@code true} if the library cell is a LUT (LUT1, LUT2, etc.), {@code false} otherwise.
 	 */
 	@Override


### PR DESCRIPTION
Note: This PR should not be accepted until [Tincr PR 89](https://github.com/byuccl/tincr/pull/89) is accepted.

This PR addresses issue #364, where Vivado cannot place LUT RAM macros in a design after the LUT RAM macros have been flattened by RapidSmith2. This PR creates RPMs for the LUT RAM macros using additional functionality added to Tincr. With these RPMs in place, Vivado creates the correct implicit placer shapes when reading the netlist and can place the LUT RAMs. Note that if the user unplaces a design in Vivado, this will also unplace the BEL constraints that are added as part of the RPM and the LUT RAMs will again be unplace-able. I have found no way around this.

Suggestions/improvements are very much welcome.