### PR TITLE
Revert #365 and only flatten placed macros in EDIF export

### DIFF
--- a/devices/artix7/cellLibrary.xml
+++ b/devices/artix7/cellLibrary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2019 Brigham Young University
+ ~ Copyright (c) 2016 Brigham Young University
  ~ 
  ~ This file is part of the BYU RapidSmith Tools.
 
@@ -67466,31 +67466,6 @@
                 <type>IBUFDS</type>
             </internal>
         </cells>
-        <rpms>
-            <rpm>
-              <type>IOB33M</type>
-              <internal>
-                <name>IBUFDS</name>
-                <bel>
-                  <id>
-                    <site_type>IOB33M</site_type>
-                    <name>INBUF_EN</name>
-                  </id>
-                </bel>
-                <rloc>X0Y0</rloc>
-              </internal>
-              <internal>
-                <name>IBUFDS_0</name>
-                <bel>
-                  <id>
-                    <site_type>IOB33S</site_type>
-                    <name>INBUF_EN</name>
-                  </id>
-                </bel>
-                <rloc>X0Y1</rloc>
-              </internal>
-            </rpm>
-        </rpms>
         <pins>
             <pin>
                 <name>O</name>

--- a/devices/zynq/cellLibrary.xml
+++ b/devices/zynq/cellLibrary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2019 Brigham Young University
+ ~ Copyright (c) 2016 Brigham Young University
  ~ 
  ~ This file is part of the BYU RapidSmith Tools.
 
@@ -99223,31 +99223,6 @@
                 <type>IBUFDS</type>
             </internal>
         </cells>
-        <rpms>
-            <rpm>
-              <type>IOB33M</type>
-              <internal>
-                <name>IBUFDS</name>
-                <bel>
-                  <id>
-                    <site_type>IOB33M</site_type>
-                    <name>INBUF_EN</name>
-                  </id>
-                </bel>
-                <rloc>X0Y0</rloc>
-              </internal>
-              <internal>
-                <name>IBUFDS_0</name>
-                <bel>
-                  <id>
-                    <site_type>IOB33S</site_type>
-                    <name>INBUF_EN</name>
-                  </id>
-                </bel>
-                <rloc>X0Y1</rloc>
-              </internal>
-            </rpm>
-        </rpms>
         <pins>
             <pin>
                 <name>O</name>

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Cell.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Cell.java
@@ -242,6 +242,10 @@ public class Cell {
 	 * Returns true if this cell is placed on a BEL.
 	 */
 	public final boolean isPlaced() {
+		if (libCell.isMacro()) {
+			return internalCells.values().stream().allMatch(Cell::isPlaced);
+		}
+
 		return bel != null;
 	}
 

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
@@ -268,7 +268,6 @@ public class CellLibrary implements Iterable<LibraryCell> {
 		LibraryMacro macroCell = new LibraryMacro(type);
 
 		loadInternalCellsFromXml(macroEl, macroCell);
-		loadRpmsFromXml(macroEl, macroCell);
 		loadPinsFromXml(macroEl, macroCell);
 		loadInternalNetsFromXml(macroEl, macroCell);
 		add(macroCell);
@@ -313,26 +312,6 @@ public class CellLibrary implements Iterable<LibraryCell> {
 		libCell.setLibraryPins(pins);
 	}
 
-	private void loadRpmsFromXml(Element macroEl, LibraryMacro macroCell) {
-		Element rpmsEl = macroEl.getChild("rpms");
-
-		for (Element rpmEl : rpmsEl.getChildren("rpm")) {
-			SiteType macroSiteType = SiteType.valueOf(familyType, rpmEl.getChildText("type"));
-			for (Element internalEl : rpmEl.getChildren("internal")) {
-				String internalCellName = internalEl.getChildText("name");
-				Element belEl = internalEl.getChild("bel");
-				Element id = belEl.getChild("id");
-				String site_type = id.getChildText("site_type");
-				BelId belId = new BelId(
-						SiteType.valueOf(familyType, site_type),
-						id.getChildText("name")
-				);
-				String rloc = internalEl.getChildText("rloc");
-				macroCell.addRpmCellEntry(macroSiteType, internalCellName, belId, rloc);
-			}
-		}
-	}
-	
 	private void loadInternalCellsFromXml(Element macroEl, LibraryMacro macroCell) {
 		
 		Element cellsEl = macroEl.getChild("cells");

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryMacro.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryMacro.java
@@ -30,8 +30,6 @@ import java.util.regex.Pattern;
 
 import edu.byu.ece.rapidSmith.design.NetType;
 import edu.byu.ece.rapidSmith.device.BelId;
-import edu.byu.ece.rapidSmith.device.SiteType;
-import edu.byu.ece.rapidSmith.util.Exceptions;
 
 /**
  * Represents a primitive MACRO cell from Vivado cell library. A macro library 
@@ -44,10 +42,9 @@ public class LibraryMacro extends LibraryCell {
 
 	private Map<LibraryPin, List<InternalPin>> pinMap;
 	private Map<String, String> internalToExternalPinMap;
-	private Map<String, InternalCell> internalCells;
+	private List<InternalCell> internalCells;
 	private List<InternalNet> internalNets;
 	private Map<String, Integer> pinOffsetMap;
-	private static Map<SiteType, RPM> rpmsMap;
 	private static Pattern pinNamePattern;
 	private static Pattern lutramPattern;
 	
@@ -67,8 +64,7 @@ public class LibraryMacro extends LibraryCell {
 		super(name);
 		pinMap = new HashMap<>();
 		internalToExternalPinMap = new HashMap<>();
-		internalCells = new HashMap<>();
-		rpmsMap = new HashMap<>();
+		internalCells = new ArrayList<>();
 	}
 
 	@Override
@@ -170,27 +166,9 @@ public class LibraryMacro extends LibraryCell {
 	 * @param libCell Internal cell type 
 	 */
 	void addInternalCell(String name, SimpleLibraryCell libCell) {
-		this.internalCells.put(name, new InternalCell(name, libCell));
+		this.internalCells.add(new InternalCell(name, libCell));
 	}
 
-	/**
-	 * Adds an entry for an internal cell to the RPM map.
-	 * @param siteType the site type of the particular RPM
-	 * @param internalCellName name of the internal cell
-	 * @param belId the belID the internal cell can be placed on for the RPM
-	 * @param rloc the RLOC of the internal cell for the RPM
-	 */
-	void addRpmCellEntry(SiteType siteType, String internalCellName, BelId belId, String rloc) {
-		RPM rpm = rpmsMap.computeIfAbsent(siteType, s -> new RPM(siteType));
-		InternalCell internalCell = internalCells.get(internalCellName);
-		if (internalCell == null) {
-			throw new Exceptions.ParseException("Internal Cell referenced in macro RPM xml \"" + internalCellName +
-					"\" not found \"");
-		}
-
-		rpm.addCellEntry(internalCell, belId, rloc);
-	}
-	
 	/**
 	 * Adds a new {@link InternalNet} to the library macro.
 	 * 
@@ -220,31 +198,9 @@ public class LibraryMacro extends LibraryCell {
 		assert (internalPin.isInternal()) : "Input cell pin to this function must be internal" ;
 		
 		String pinName = internalPin.getFullName();
-		String relativePinName = pinName.substring(pinName.indexOf("/") + 1);
-		
-		return macroCell.getPin(internalToExternalPinMap.get(relativePinName));		
-	}
+		String relativePinName = pinName.substring(pinName.substring(0, pinName.lastIndexOf("/")).lastIndexOf("/")+1);
 
-	/**
-	 * Adds RPM EDIF properties to an internal cell. Currently only works for LUTRAM internal cells.
-	 * @param internalCell the internal cell to add the RPM properties to.
-	 * @param cell the cell instance of the internal cell
-	 */
-	private void addInternalCellRPMProperties(InternalCell internalCell, Cell cell) {
-		// Get site type to RPM map
-		// There is only one site type a LUT RAM can be placed on, so grab the first one
-		RPM rpm = rpmsMap.values().iterator().next();
-		BelIdRlocPair belIdRlocPair = rpm.getCellToBelRlocMap().get(internalCell);
-
-		// Add a U_SET property for the internal cell
-		cell.getProperties().update("U_SET", PropertyType.EDIF, cell.getParent().getName());
-
-		// Add the BEL constraint. Internal cells BEL constraints cannot change and need to be in place
-		// to ensure Vivado can place the macro (at least in the case of LUT RAMs).
-		cell.getProperties().update("BEL", PropertyType.EDIF, belIdRlocPair.getBelId().getName());
-
-		// Set the RLOC property
-		cell.getProperties().update("RLOC", PropertyType.EDIF, belIdRlocPair.getRloc());
+		return macroCell.getPin(internalToExternalPinMap.get(relativePinName));
 	}
 	
 	/**
@@ -258,19 +214,11 @@ public class LibraryMacro extends LibraryCell {
 		Map<String, Cell> internalCellMap = new HashMap<>();
 		String parentName = parent.getName();
 		
-		for (InternalCell internalCell : internalCells.values()) {
+		for (InternalCell internalCell : internalCells) {
 			String fullCellName = parentName + "/" + internalCell.getName();
 			Cell cell = new Cell(fullCellName, internalCell.getLeafCell());
 			cell.setParent(parent);
 			internalCellMap.put(fullCellName, cell);
-
-			// For now, only add an RPM for LUTRAM macros. LUTRAM macros can only be placed in one exact way
-			// (on a SLICEM), whereas other macros have more than one possible type of placement
-			// (see the IOBUF macro for an example). Additionally, only LUTRAM macros seem to need to have RPMs in
-			// place for Vivado to create the correct placer macros when it reads the EDIF.
-			if (parent.getLibCell().isLutRamMacro()) {
-				addInternalCellRPMProperties(internalCell, cell);
-			}
 		}
 		
 		return internalCellMap;	
@@ -443,52 +391,6 @@ public class LibraryMacro extends LibraryCell {
 		public String getPinName() {
 			return pinName;
 		}
-	}
-
-	/**
-	 * A Bel ID and RLOC pair.
-	 */
-	private class BelIdRlocPair {
-		private final BelId belId;
-		private final String rloc;
-
-		public BelIdRlocPair(BelId belId, String rloc) {
-			this.belId = belId;
-			this.rloc = rloc;
-		}
-
-		public BelId getBelId() {
-			return belId;
-		}
-
-		public String getRloc() {
-			return rloc;
-		}
-
-	}
-
-	/**
-	 * An RPM for a library macro. There may be multiple RPMs for a given library macro.
-	 */
-	private class RPM {
-		/** The site type the whole macro is placed on for this RPM. Used as an identifier **/
-		private SiteType siteType;
-
-		public Map<InternalCell, BelIdRlocPair> getCellToBelRlocMap() {
-			return cellToBelRlocMap;
-		}
-
-		private Map<InternalCell, BelIdRlocPair> cellToBelRlocMap;
-
-		public RPM(SiteType siteType) {
-			this.siteType = siteType;
-			this.cellToBelRlocMap = new HashMap<>();
-		}
-
-		public void addCellEntry(InternalCell internalCell, BelId belId, String rloc) {
-			cellToBelRlocMap.put(internalCell, new BelIdRlocPair(belId, rloc));
-		}
-
 	}
 
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
@@ -26,12 +26,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import edu.byu.ece.edif.core.BooleanTypedValue;
 import edu.byu.ece.edif.core.EdifCell;
@@ -84,12 +84,20 @@ import edu.byu.ece.rapidSmith.util.Exceptions;
 public final class EdifInterface {
 
 	private static boolean suppressWarnings = false;
-	
+	private static boolean suppressInfoMessages = false;
+
 	/**
 	 * Suppress non-critical warnings while parsing an EDIF file. 
 	 */
 	public static void suppressWarnings(boolean suppress) {
 		suppressWarnings = suppress;
+	}
+
+	/**
+	 * Suppress info messages while parsing an EDIF file.
+	 */
+	public static void suppressInfoMessages(boolean suppress) {
+		suppressInfoMessages = suppress;
 	}
 	
 	/* ********************
@@ -536,22 +544,26 @@ public final class EdifInterface {
 	 * Returns a hashset of all unique library cells in a given design
 	 */
 	private static HashSet<LibraryCell> getUniqueLibraryCellsInDesign(CellDesign design) {
-		
 		HashSet<LibraryCell> uniqueLibraryCells = new HashSet<>();
-		
-		Iterator<Cell> cellIt = design.getLeafCells().iterator();
-		
-		// for (Cell c : design.getCells()) {
-		while (cellIt.hasNext()) {
-			Cell c = cellIt.next();
-			
-			if (!c.isPort())
-				uniqueLibraryCells.add(c.getLibCell());
+
+		for (Cell cell : design.getCells()) {
+			if (!cell.isPort()) {
+				if (cell.isMacro() && cell.isPlaced()) {
+					for (Cell internalCell : cell.getInternalCells()) {
+						uniqueLibraryCells.add(internalCell.getLibCell());
+					}
+				} else {
+					// If the macro cell has not been placed, include the full macro in the EDIF.
+					// If the full macro for unplaced LUTRAMs is not included in the EDIF, Vivado will
+					// be unable to place them.
+					uniqueLibraryCells.add(cell.getLibCell());
+				}
+			}
 		}
-		
+
 		return uniqueLibraryCells;
 	}
-	
+
 	/*
 	 * Creates the top level EDIF cell that contains the design
 	 */
@@ -565,22 +577,32 @@ public final class EdifInterface {
 		topLevelCell.setInterface(cellInterface);
 		
 		// create the cell instances
-		Iterator<Cell> cellIt = design.getLeafCells().iterator();
-		while (cellIt.hasNext()) {
-			Cell cell = cellIt.next();
-			
+		for (Cell cell : design.getCells()) {
 			if (cell.isPort())
 				continue;
-			
-			EdifCell edifLibCell = cellMap.get(cell.getLibCell());
-			topLevelCell.addSubCell( createEdifCellInstance(cell, topLevelCell, edifLibCell) );
+
+			if (cell.isMacro() && cell.isPlaced()) {
+				if (!suppressInfoMessages)
+					System.out.println("[Info] Macro cell " + cell.getName() + " is placed and will be flattened.");
+
+				for (Cell internalCell : cell.getInternalCells()) {
+					EdifCell edifLibCell = cellMap.get(internalCell.getLibCell());
+					topLevelCell.addSubCell(createEdifCellInstance(internalCell, topLevelCell, edifLibCell));
+				}
+			} else {
+				if (cell.isMacro() && !suppressInfoMessages)
+					System.out.println("[Info] Macro cell " + cell.getName() + " is unplaced and will NOT be flattened.");
+
+				EdifCell edifLibCell = cellMap.get(cell.getLibCell());
+				topLevelCell.addSubCell(createEdifCellInstance(cell, topLevelCell, edifLibCell));
+			}
 		}
 		
 		// create the net instances
 		for (CellNet net : design.getNets()) {
 		 	topLevelCell.addNet(createEdifNet(net, topLevelCell, portInfoMap));
 		}
-			
+
 		topLevelCell.addPropertyList(createEdifPropertyList(design.getProperties()));
 		return topLevelCell; 
 	}
@@ -607,7 +629,7 @@ public final class EdifInterface {
 					int busMember = Integer.parseInt(m.group(2));
 					PortInformation portInfo = portMap.getOrDefault(portName, new PortInformation(portName, direction, false, busMember));
 					portInfo.addPort(busMember);
-					portMap.computeIfAbsent(portName, k -> portInfo);
+					portMap.putIfAbsent(portName, portInfo);
 					portInfoMap.put(cell, portInfo);
 				} 
 				else {
@@ -622,7 +644,7 @@ public final class EdifInterface {
 			String portName = entry.getKey();
 			PortInformation portInfo = entry.getValue();
 			
-			EdifNameable edifPortName = null;
+			EdifNameable edifPortName;
 			
 			if (portInfo.isSingleBitPort()) {
 				// some single-bit ports can be names like port[0]...which matches the bus pattern for port names...
@@ -663,16 +685,16 @@ public final class EdifInterface {
 	 */
 	private static EdifNet createEdifNet(CellNet cellNet, EdifCell edifParentCell, Map<Cell, PortInformation> portInfoMap) {
 		EdifNet edifNet = new EdifNet(createEdifNameable(cellNet.getName()), edifParentCell);
-				
+
 		// create the port references for the edif net
-		for (CellPin cellPin : cellNet.getPins()) {
-			
+		for (CellPin cellPin : getEdifNetPins(cellNet)) {
+
 			if (cellPin.isPseudoPin()) {
 				continue;
 			}
 						
 			Cell parentCell = cellPin.getCell();
-			
+
 			EdifPortRef portRef = parentCell.isPort() ?
 									createEdifPortRefFromPort(parentCell, edifParentCell, edifNet, portInfoMap.get(parentCell).getMin()) : 
 									createEdifPortRefFromCellPin(cellPin, edifParentCell, edifNet) ;
@@ -712,8 +734,8 @@ public final class EdifInterface {
 	 * to the connection.
 	 */
 	private static EdifPortRef createEdifPortRefFromCellPin(CellPin cellPin, EdifCell edifParent, EdifNet edifNet) {
-		
 		EdifCellInstance cellInstance = edifParent.getCellInstance(getEdifName(cellPin.getCell().getName()));
+
 		EdifCell libCell = cellInstance.getCellType();
 		
 		String[] toks = cellPin.getName().split("\\["); 
@@ -742,18 +764,19 @@ public final class EdifInterface {
 		for (Property prop : properties) {
 			// The key and value of the property need sensible toString() methods when exporting to EDIF
 			// this function is for creating properties for printing only!
-			// TODO: make sure to inform the user of this 
-			if (prop.getType().equals(PropertyType.EDIF)){/**Only get PropertyType EDIF when creating EDIF propertyList*/
+			// TODO: make sure to inform the user of this
+			// Only get PropertyType EDIF when creating EDIF propertyList
+			if (prop.getType().equals(PropertyType.EDIF)){
 				edu.byu.ece.edif.core.Property edifProperty;
 
 				Object value = prop.getValue();
 
 				if (value instanceof Boolean) {
-					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey().toString(), (Boolean) value);
+					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey(), (Boolean) value);
 				} else if (value instanceof Integer) {
-					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey().toString(), (Integer) value);
+					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey(), (Integer) value);
 				} else {
-					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey().toString(), prop.getValue().toString());
+					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey(), prop.getValue().toString());
 				}
 
 				edifProperties.addProperty(edifProperty);
@@ -841,4 +864,20 @@ public final class EdifInterface {
 		
 		return PortDirection.isInputPort(portCell) ? EdifPort.IN : EdifPort.OUT; 
 	}
+
+
+	/**
+	 * Returns the cell pins of a net, returning macro cell pins in place of
+	 * internal cell pins if the corresponding internal cell has not been placed.
+	 * @return
+	 */
+	private static Collection<CellPin> getEdifNetPins(CellNet net) {
+		return net.getPins().stream().map(p -> {
+			if (p.isInternal() && !p.getCell().isPlaced())
+				return p.getExternalPin();
+			return p;
+		})
+				.collect(Collectors.toSet());
+	}
+
 }

--- a/src/test/java/design/rscpImport/ImportTests.java
+++ b/src/test/java/design/rscpImport/ImportTests.java
@@ -34,6 +34,7 @@ public class ImportTests {
 	@BeforeAll
 	public static void initializeClass() {
 		EdifInterface.suppressWarnings(true);
+		EdifInterface.suppressInfoMessages(true);
 	}
 	
 	@Test


### PR DESCRIPTION
This reverts #365 mainly because it was relying on some assumptions that turned out to not be universally true. For instance, it was assumed that there would only be one correct placement for LUTRAM macros. However, as seen with RAM32X1S macros (and some other types), this is not the case. Creating RPMs or XDC macros may be possibly incorporated in the future.

For now, this PR fixes the issue seen in #364 by not flattening macro cells in the EDIF if they have not been placed. If they have been placed, they are flattened as before. Info messages are printed out to inform the user which macro cells are being flattened and which are not. These messages can be disabled.