### PR TITLE
Yosys Interface, Abstract Edif Interface, CARRY4 transformation

### DIFF
--- a/devices/artix7/cellLibrary.xml
+++ b/devices/artix7/cellLibrary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2019 Brigham Young University
+ ~ Copyright (c) 2016 Brigham Young University
  ~ 
  ~ This file is part of the BYU RapidSmith Tools.
 
@@ -67466,31 +67466,6 @@
                 <type>IBUFDS</type>
             </internal>
         </cells>
-        <rpms>
-            <rpm>
-              <type>IOB33M</type>
-              <internal>
-                <name>IBUFDS</name>
-                <bel>
-                  <id>
-                    <site_type>IOB33M</site_type>
-                    <name>INBUF_EN</name>
-                  </id>
-                </bel>
-                <rloc>X0Y0</rloc>
-              </internal>
-              <internal>
-                <name>IBUFDS_0</name>
-                <bel>
-                  <id>
-                    <site_type>IOB33S</site_type>
-                    <name>INBUF_EN</name>
-                  </id>
-                </bel>
-                <rloc>X0Y1</rloc>
-              </internal>
-            </rpm>
-        </rpms>
         <pins>
             <pin>
                 <name>O</name>

--- a/devices/zynq/cellLibrary.xml
+++ b/devices/zynq/cellLibrary.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2019 Brigham Young University
+ ~ Copyright (c) 2016 Brigham Young University
  ~ 
  ~ This file is part of the BYU RapidSmith Tools.
 
@@ -99223,31 +99223,6 @@
                 <type>IBUFDS</type>
             </internal>
         </cells>
-        <rpms>
-            <rpm>
-              <type>IOB33M</type>
-              <internal>
-                <name>IBUFDS</name>
-                <bel>
-                  <id>
-                    <site_type>IOB33M</site_type>
-                    <name>INBUF_EN</name>
-                  </id>
-                </bel>
-                <rloc>X0Y0</rloc>
-              </internal>
-              <internal>
-                <name>IBUFDS_0</name>
-                <bel>
-                  <id>
-                    <site_type>IOB33S</site_type>
-                    <name>INBUF_EN</name>
-                  </id>
-                </bel>
-                <rloc>X0Y1</rloc>
-              </internal>
-            </rpm>
-        </rpms>
         <pins>
             <pin>
                 <name>O</name>

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Cell.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/Cell.java
@@ -242,6 +242,10 @@ public class Cell {
 	 * Returns true if this cell is placed on a BEL.
 	 */
 	public final boolean isPlaced() {
+		if (libCell.isMacro()) {
+			return internalCells.values().stream().allMatch(Cell::isPlaced);
+		}
+
 		return bel != null;
 	}
 

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellLibrary.java
@@ -268,7 +268,6 @@ public class CellLibrary implements Iterable<LibraryCell> {
 		LibraryMacro macroCell = new LibraryMacro(type);
 
 		loadInternalCellsFromXml(macroEl, macroCell);
-		loadRpmsFromXml(macroEl, macroCell);
 		loadPinsFromXml(macroEl, macroCell);
 		loadInternalNetsFromXml(macroEl, macroCell);
 		add(macroCell);
@@ -313,26 +312,6 @@ public class CellLibrary implements Iterable<LibraryCell> {
 		libCell.setLibraryPins(pins);
 	}
 
-	private void loadRpmsFromXml(Element macroEl, LibraryMacro macroCell) {
-		Element rpmsEl = macroEl.getChild("rpms");
-
-		for (Element rpmEl : rpmsEl.getChildren("rpm")) {
-			SiteType macroSiteType = SiteType.valueOf(familyType, rpmEl.getChildText("type"));
-			for (Element internalEl : rpmEl.getChildren("internal")) {
-				String internalCellName = internalEl.getChildText("name");
-				Element belEl = internalEl.getChild("bel");
-				Element id = belEl.getChild("id");
-				String site_type = id.getChildText("site_type");
-				BelId belId = new BelId(
-						SiteType.valueOf(familyType, site_type),
-						id.getChildText("name")
-				);
-				String rloc = internalEl.getChildText("rloc");
-				macroCell.addRpmCellEntry(macroSiteType, internalCellName, belId, rloc);
-			}
-		}
-	}
-	
 	private void loadInternalCellsFromXml(Element macroEl, LibraryMacro macroCell) {
 		
 		Element cellsEl = macroEl.getChild("cells");

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryMacro.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/LibraryMacro.java
@@ -30,8 +30,6 @@ import java.util.regex.Pattern;
 
 import edu.byu.ece.rapidSmith.design.NetType;
 import edu.byu.ece.rapidSmith.device.BelId;
-import edu.byu.ece.rapidSmith.device.SiteType;
-import edu.byu.ece.rapidSmith.util.Exceptions;
 
 /**
  * Represents a primitive MACRO cell from Vivado cell library. A macro library 
@@ -44,10 +42,9 @@ public class LibraryMacro extends LibraryCell {
 
 	private Map<LibraryPin, List<InternalPin>> pinMap;
 	private Map<String, String> internalToExternalPinMap;
-	private Map<String, InternalCell> internalCells;
+	private List<InternalCell> internalCells;
 	private List<InternalNet> internalNets;
 	private Map<String, Integer> pinOffsetMap;
-	private static Map<SiteType, RPM> rpmsMap;
 	private static Pattern pinNamePattern;
 	private static Pattern lutramPattern;
 	
@@ -67,8 +64,7 @@ public class LibraryMacro extends LibraryCell {
 		super(name);
 		pinMap = new HashMap<>();
 		internalToExternalPinMap = new HashMap<>();
-		internalCells = new HashMap<>();
-		rpmsMap = new HashMap<>();
+		internalCells = new ArrayList<>();
 	}
 
 	@Override
@@ -170,27 +166,9 @@ public class LibraryMacro extends LibraryCell {
 	 * @param libCell Internal cell type 
 	 */
 	void addInternalCell(String name, SimpleLibraryCell libCell) {
-		this.internalCells.put(name, new InternalCell(name, libCell));
+		this.internalCells.add(new InternalCell(name, libCell));
 	}
 
-	/**
-	 * Adds an entry for an internal cell to the RPM map.
-	 * @param siteType the site type of the particular RPM
-	 * @param internalCellName name of the internal cell
-	 * @param belId the belID the internal cell can be placed on for the RPM
-	 * @param rloc the RLOC of the internal cell for the RPM
-	 */
-	void addRpmCellEntry(SiteType siteType, String internalCellName, BelId belId, String rloc) {
-		RPM rpm = rpmsMap.computeIfAbsent(siteType, s -> new RPM(siteType));
-		InternalCell internalCell = internalCells.get(internalCellName);
-		if (internalCell == null) {
-			throw new Exceptions.ParseException("Internal Cell referenced in macro RPM xml \"" + internalCellName +
-					"\" not found \"");
-		}
-
-		rpm.addCellEntry(internalCell, belId, rloc);
-	}
-	
 	/**
 	 * Adds a new {@link InternalNet} to the library macro.
 	 * 
@@ -220,31 +198,9 @@ public class LibraryMacro extends LibraryCell {
 		assert (internalPin.isInternal()) : "Input cell pin to this function must be internal" ;
 		
 		String pinName = internalPin.getFullName();
-		String relativePinName = pinName.substring(pinName.indexOf("/") + 1);
-		
-		return macroCell.getPin(internalToExternalPinMap.get(relativePinName));		
-	}
+		String relativePinName = pinName.substring(pinName.substring(0, pinName.lastIndexOf("/")).lastIndexOf("/")+1);
 
-	/**
-	 * Adds RPM EDIF properties to an internal cell. Currently only works for LUTRAM internal cells.
-	 * @param internalCell the internal cell to add the RPM properties to.
-	 * @param cell the cell instance of the internal cell
-	 */
-	private void addInternalCellRPMProperties(InternalCell internalCell, Cell cell) {
-		// Get site type to RPM map
-		// There is only one site type a LUT RAM can be placed on, so grab the first one
-		RPM rpm = rpmsMap.values().iterator().next();
-		BelIdRlocPair belIdRlocPair = rpm.getCellToBelRlocMap().get(internalCell);
-
-		// Add a U_SET property for the internal cell
-		cell.getProperties().update("U_SET", PropertyType.EDIF, cell.getParent().getName());
-
-		// Add the BEL constraint. Internal cells BEL constraints cannot change and need to be in place
-		// to ensure Vivado can place the macro (at least in the case of LUT RAMs).
-		cell.getProperties().update("BEL", PropertyType.EDIF, belIdRlocPair.getBelId().getName());
-
-		// Set the RLOC property
-		cell.getProperties().update("RLOC", PropertyType.EDIF, belIdRlocPair.getRloc());
+		return macroCell.getPin(internalToExternalPinMap.get(relativePinName));
 	}
 	
 	/**
@@ -258,19 +214,11 @@ public class LibraryMacro extends LibraryCell {
 		Map<String, Cell> internalCellMap = new HashMap<>();
 		String parentName = parent.getName();
 		
-		for (InternalCell internalCell : internalCells.values()) {
+		for (InternalCell internalCell : internalCells) {
 			String fullCellName = parentName + "/" + internalCell.getName();
 			Cell cell = new Cell(fullCellName, internalCell.getLeafCell());
 			cell.setParent(parent);
 			internalCellMap.put(fullCellName, cell);
-
-			// For now, only add an RPM for LUTRAM macros. LUTRAM macros can only be placed in one exact way
-			// (on a SLICEM), whereas other macros have more than one possible type of placement
-			// (see the IOBUF macro for an example). Additionally, only LUTRAM macros seem to need to have RPMs in
-			// place for Vivado to create the correct placer macros when it reads the EDIF.
-			if (parent.getLibCell().isLutRamMacro()) {
-				addInternalCellRPMProperties(internalCell, cell);
-			}
 		}
 		
 		return internalCellMap;	
@@ -443,52 +391,6 @@ public class LibraryMacro extends LibraryCell {
 		public String getPinName() {
 			return pinName;
 		}
-	}
-
-	/**
-	 * A Bel ID and RLOC pair.
-	 */
-	private class BelIdRlocPair {
-		private final BelId belId;
-		private final String rloc;
-
-		public BelIdRlocPair(BelId belId, String rloc) {
-			this.belId = belId;
-			this.rloc = rloc;
-		}
-
-		public BelId getBelId() {
-			return belId;
-		}
-
-		public String getRloc() {
-			return rloc;
-		}
-
-	}
-
-	/**
-	 * An RPM for a library macro. There may be multiple RPMs for a given library macro.
-	 */
-	private class RPM {
-		/** The site type the whole macro is placed on for this RPM. Used as an identifier **/
-		private SiteType siteType;
-
-		public Map<InternalCell, BelIdRlocPair> getCellToBelRlocMap() {
-			return cellToBelRlocMap;
-		}
-
-		private Map<InternalCell, BelIdRlocPair> cellToBelRlocMap;
-
-		public RPM(SiteType siteType) {
-			this.siteType = siteType;
-			this.cellToBelRlocMap = new HashMap<>();
-		}
-
-		public void addCellEntry(InternalCell internalCell, BelId belId, String rloc) {
-			cellToBelRlocMap.put(internalCell, new BelIdRlocPair(belId, rloc));
-		}
-
 	}
 
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/device/vsrt/primitiveDefs/PrimitiveDef.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/vsrt/primitiveDefs/PrimitiveDef.java
@@ -227,7 +227,6 @@ public class PrimitiveDef implements Serializable{
 	/**
 	 * Generates the connections for each bel in the primitive site
 	 * @param element
-	 * @param pipNames
 	 */
 	private void generateBelConnections(Element element){
 		for (PrimitiveDefPin pin : element.getPins()) {

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/AbstractEdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/AbstractEdifInterface.java
@@ -1,0 +1,371 @@
+package edu.byu.ece.rapidSmith.interfaces;
+
+import edu.byu.ece.edif.core.*;
+import edu.byu.ece.rapidSmith.design.NetType;
+import edu.byu.ece.rapidSmith.design.subsite.*;
+import edu.byu.ece.rapidSmith.design.subsite.Property;
+import edu.byu.ece.rapidSmith.util.Exceptions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractEdifInterface {
+
+	protected static boolean suppressWarnings = false;
+	protected static boolean suppressInfoMessages = false;
+
+	/**
+	 * Suppress non-critical warnings while parsing an EDIF file.
+	 */
+	public static void suppressWarnings(boolean suppress) {
+		suppressWarnings = suppress;
+	}
+
+	/**
+	 * Suppress info messages while parsing an EDIF file.
+	 */
+	public static void suppressInfoMessages(boolean suppress) {
+		suppressInfoMessages = suppress;
+	}
+
+	/* ********************
+	 * 	 Import Section
+	 *********************/
+
+	public abstract CellDesign parseEdif(String edifFile, CellLibrary libCells, String partName);
+
+	/**
+	 * Converts EDIF cell instances to equivalent RapidSmith cells and adds them to the design
+	 * @param design
+	 * @param edifCellInstances
+	 * @param libCells
+	 * @param vccNets
+	 * @param gndNets
+	 */
+		protected void processEdifCells(CellDesign design, Collection<EdifCellInstance> edifCellInstances, CellLibrary libCells, List<CellNet> vccNets, List<CellNet> gndNets) {
+		if (edifCellInstances == null || edifCellInstances.size() == 0) {
+			if (!suppressWarnings) {
+				System.err.println("[Warning] No cells found in the edif netlist");
+			}
+			return;
+		}
+
+		// create equivalent RS2 cells from the edif cell instances
+		for(EdifCellInstance eci : edifCellInstances) {
+			// create the corresponding RS2 cell
+			LibraryCell lcType = libCells.get(eci.getType());
+			if (lcType == null) {
+				throw new Exceptions.ParseException("Unable to find library cell of type: " + eci.getType());
+			}
+
+			// Check for naming conflicts and rename cells as required...this should not be necessary for designs
+			// synthesized and implemented in Vivado, but if the netlist is manipulated by an external tool,
+			// this can happen
+			if (design.hasCell(eci.getOldName())) {
+				handleNamingConflict(design, design.getCell(eci.getOldName()));
+			}
+
+			Cell newcell = design.addCell(new Cell(eci.getOldName(), lcType));
+
+			// Add properties to the cell
+			newcell.getProperties().updateAll(createCellProperties(eci.getPropertyList()));
+
+			// look for internal macro nets
+			if (newcell.isMacro()) {
+				for (CellNet net : newcell.getInternalNets()) {
+					if (net.isVCCNet()) {
+						vccNets.add(net);
+					}
+					else if (net.isGNDNet()) {
+						gndNets.add(net);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Some EDIF netlists from Vivado can have identical port and cell names. This function renames the ports
+	 * so that there is no naming conflict in RapidSmith.
+	 *
+	 * @param design CellDesign
+	 * @param cell Cell to rename (should be a port cell)
+	 */
+	private void handleNamingConflict (CellDesign design, Cell cell) {
+		assert cell.isPort() : "Conflicting cell names should only happen with Port cells: " + cell.getName();
+
+		// print a warning to the user
+		if (!suppressWarnings) {
+			System.err.println("[Warning] A top-level port and another cell in the netlist have identical names: " + cell.getName()
+					+ ". The port cell will be renamed to " + cell.getName() + "_rsport");
+		}
+
+		// update the name of the cell
+		design.removeCell(cell);
+		Cell newPortCell = new Cell(cell.getName() + "_rsport", cell.getLibCell());
+		design.addCell(newPortCell);
+	}
+
+	/**
+	 * Converts EDIF nets to equivalent RapidSmith nets and adds them to the design
+	 * @param design
+	 * @param edifNets
+	 * @param vccNets
+	 * @param gndNets
+	 * @param portOffsetMap
+	 */
+	protected void processEdifNets(CellDesign design, Collection<EdifNet> edifNets, List<CellNet> vccNets, List<CellNet> gndNets, Map<EdifPort, Integer> portOffsetMap) {
+
+		if (edifNets == null || edifNets.size() == 0) {
+			if (!suppressWarnings) {
+				System.err.println("[Warning] No nets found in the edif netlist");
+			}
+			return;
+		}
+
+		// Go through the cell's nets and hook up inputs and outputs
+		for(EdifNet net : edifNets) {
+
+			//create a new net
+			CellNet cn = new CellNet(net.getOldName(), NetType.WIRE);
+
+			// process all net connections
+			processNetConnections(net.getPortRefList(), design, cn, portOffsetMap);
+
+			//report a warning if no sources on a net are found
+			if (cn.getAllSourcePins().size() == 0) {
+				if (!suppressWarnings) {
+					System.err.println("[Warning] No source for net " + net.getOldName());
+				}
+			}
+
+			// Add the net to the design if is is NOT a static net.
+			// Otherwise, store it for later use (will collapse later)
+			if (cn.isVCCNet()) {
+				vccNets.add(cn);
+			}
+			else if (cn.isGNDNet()) {
+				gndNets.add(cn);
+			}
+			else {
+				design.addNet(cn);
+			}
+
+			cn.getProperties().updateAll(createCellProperties(net.getPropertyList()));
+		}
+	}
+
+	/**
+	 * Builds the connections of CellNet based on the specified EDIF port references. Returns true
+	 * if the given net is attached to a top-level port, false otherwise
+	 *
+	 * TODO: update this once top-level ports are added
+	 *
+	 * @param portRefs
+	 * @param design
+	 * @param net
+	 * @param portOffsetMap
+	 */
+	private void processNetConnections(Collection<EdifPortRef> portRefs, CellDesign design, CellNet net, Map<EdifPort, Integer> portOffsetMap) {
+
+		for (EdifPortRef portRef: portRefs) {
+
+			EdifPort port = portRef.getPort();
+
+			// Connects to a top-level port
+			if (portRef.isTopLevelPortRef()) {
+
+				String portname = portRef.isSingleBitPortRef() ? port.getOldName() :
+						String.format("%s[%d]", getPortNamePrefix(port.getOldName()), reverseBusIndex(port.getWidth(), portRef.getBusMember(), portOffsetMap.get(port)));
+
+				Cell portCell = design.getCell(portname);
+
+				if (portCell == null) {
+					throw new Exceptions.ParseException("Port Cell " + portname + " does not exist in the design!");
+				}
+				else if (!portCell.isPort()) {
+					portCell = design.getCell(portname + "_rsport");
+				}
+
+				net.connectToPin(portCell.getPin("PAD"));
+
+				continue;
+			}
+
+			Cell node = design.getCell(portRef.getCellInstance().getOldName());
+			if (node == null) {
+				throw new Exceptions.ParseException("Cell: " + portRef.getCellInstance().getOldName()  + " does not exist in the design!");
+			}
+
+			int busOffset = 0;
+			if (node.isMacro()) {
+				LibraryMacro macro = (LibraryMacro)node.getLibCell();
+				busOffset = macro.getPinOffset(port.getName());
+			}
+
+			// Connects to a cell pin
+			// TODO: take a closer look at this...I am using the edif name of a cell pin name which should be ok, but be aware
+			String pinname = portRef.isSingleBitPortRef() ? port.getName()
+					: String.format("%s[%d]", port.getName(), reverseBusIndex(port.getWidth(), portRef.getBusMember(), busOffset));
+
+			// Mark GND and VCC nets
+			if (node.isVccSource()) {
+				net.setType(NetType.VCC);
+			}
+			else if (node.isGndSource()) {
+				net.setType(NetType.GND);
+			}
+
+			net.connectToPin(node.getPin(pinname));
+		}
+	}
+
+	/**
+	 * Vivado ports that are buses are named portName[15:0]
+	 * This function will return the "portName" portion of the bus name
+	 *
+	 * @param portName
+	 * @return
+	 */
+	private String getPortNamePrefix(String portName) {
+
+		int bracketIndex = portName.lastIndexOf("[");
+		return bracketIndex == -1 ? portName : portName.substring(0, bracketIndex);
+	}
+
+	/**
+	 * Creates a list of RapidSmith cell properties from an EDIF property list
+	 * @param edifPropertyList
+	 * @return
+	 */
+	protected List<Property> createCellProperties(edu.byu.ece.edif.core.PropertyList edifPropertyList) {
+		List<Property> cellProperties = new ArrayList<>();
+
+		if (edifPropertyList != null) {
+			for (String keyName : edifPropertyList.keySet()) {
+				edu.byu.ece.edif.core.Property property = edifPropertyList.getProperty(keyName);
+				Property prop = new Property(property.getName(), PropertyType.EDIF, getValueFromEdifType(property.getValue()));
+				cellProperties.add(prop);
+			}
+		}
+
+		return cellProperties;
+	}
+
+	/**
+	 * Converts an EdifTypedValue to the corresponding native Java type
+	 * @param typedValue
+	 * @return
+	 */
+	private Object getValueFromEdifType(EdifTypedValue typedValue) {
+
+		Object value;
+		if (typedValue instanceof IntegerTypedValue) {
+			value = ((IntegerTypedValue)typedValue).getIntegerValue();
+		}
+		else if (typedValue instanceof BooleanTypedValue) {
+			value = ((BooleanTypedValue)typedValue).getBooleanValue();
+		}
+		else  { // default is string type
+			value = ((StringTypedValue)typedValue).getStringValue();
+		}
+		return value;
+	}
+
+	/**
+	 * Because EDIF files reverse the index of bus members, this function
+	 * is used to get the original index of a port into a bus.
+	 *
+	 * @param width
+	 * @param busMember
+	 * @param offset
+	 * @return
+	 */
+	protected static int reverseBusIndex(int width, int busMember, int offset) {
+		return width - 1 - busMember + offset;
+	}
+
+	/**
+	 *
+	 * @param design
+	 * @param libCells
+	 * @param vccNets
+	 * @param gndNets
+	 */
+	protected void collapseStaticNets(CellDesign design, CellLibrary libCells, List<CellNet> vccNets, List<CellNet> gndNets) {
+		// Create new global VCC/GND cells and nets
+		Cell globalVCC = new Cell("RapidSmithGlobalVCC", libCells.getVccSource());
+		Cell globalGND = new Cell("RapidSmithGlobalGND", libCells.getGndSource());
+		CellNet globalVCCNet = new CellNet("RapidSmithGlobalVCCNet", NetType.VCC);
+		CellNet globalGNDNet = new CellNet("RapidSmithGlobalGNDNet", NetType.GND);
+
+		// Connect the global sources to the global nets
+		globalVCCNet.connectToPin(globalVCC.getOutputPins().iterator().next());
+		globalGNDNet.connectToPin(globalGND.getOutputPins().iterator().next());
+
+		// Add all VCC/GND sink pins to the global nets
+		for(CellNet net : vccNets) {
+			transferSinkPins(net, globalVCCNet);
+		}
+
+		for(CellNet net : gndNets) {
+			transferSinkPins(net, globalGNDNet);
+		}
+
+		// Remove the old VCC/GND cells from the list
+		List<Cell> cellsToRemove = new ArrayList<>();
+		for (Cell cell : design.getCells()) {
+			if (cell.isVccSource() || cell.isGndSource()) {
+				cellsToRemove.add(cell);
+			}
+		}
+		cellsToRemove.forEach(design::removeCell);
+
+		// Add the new master cells/nets to the design
+		design.addCell(globalVCC);
+		design.addNet(globalVCCNet);
+		design.addCell(globalGND);
+		design.addNet(globalGNDNet);
+
+		// For macro pins tied to power or ground, make them point to the appropriate global static net
+		for (Cell c : design.getCells()) {
+			for (CellPin cp : c.getPins()) {
+				if (cp.getNet()!= null) {
+					if (cp.getNet() != globalGNDNet && cp.getNet().getType() == NetType.GND)
+						cp.setMacroPinToGlobalNet(globalGNDNet);
+					else if (cp.getNet() != globalVCCNet && cp.getNet().getType() == NetType.VCC)
+						cp.setMacroPinToGlobalNet(globalVCCNet);
+				}
+			}
+		}
+
+	}
+
+	/**
+	 *
+	 * @param oldNet
+	 * @param newNet
+	 */
+	private static void transferSinkPins(CellNet oldNet, CellNet newNet) {
+		Collection<CellPin> sinkPins = oldNet.getSinkPins();
+		oldNet.detachNet();
+		oldNet.unrouteFull();
+		newNet.connectToPins(sinkPins);
+	}
+
+	/* *********************
+	 *    Export Section
+	 ***********************/
+
+	/**
+	 *
+	 * @param edifOutputFile
+	 * @param design
+	 * @throws IOException
+	 */
+	public abstract void writeEdif(String edifOutputFile, CellDesign design) throws IOException;
+
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/EdifInterface.java
@@ -26,12 +26,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import edu.byu.ece.edif.core.BooleanTypedValue;
 import edu.byu.ece.edif.core.EdifCell;
@@ -84,12 +84,20 @@ import edu.byu.ece.rapidSmith.util.Exceptions;
 public final class EdifInterface {
 
 	private static boolean suppressWarnings = false;
-	
+	private static boolean suppressInfoMessages = false;
+
 	/**
 	 * Suppress non-critical warnings while parsing an EDIF file. 
 	 */
 	public static void suppressWarnings(boolean suppress) {
 		suppressWarnings = suppress;
+	}
+
+	/**
+	 * Suppress info messages while parsing an EDIF file.
+	 */
+	public static void suppressInfoMessages(boolean suppress) {
+		suppressInfoMessages = suppress;
 	}
 	
 	/* ********************
@@ -536,22 +544,26 @@ public final class EdifInterface {
 	 * Returns a hashset of all unique library cells in a given design
 	 */
 	private static HashSet<LibraryCell> getUniqueLibraryCellsInDesign(CellDesign design) {
-		
 		HashSet<LibraryCell> uniqueLibraryCells = new HashSet<>();
-		
-		Iterator<Cell> cellIt = design.getLeafCells().iterator();
-		
-		// for (Cell c : design.getCells()) {
-		while (cellIt.hasNext()) {
-			Cell c = cellIt.next();
-			
-			if (!c.isPort())
-				uniqueLibraryCells.add(c.getLibCell());
+
+		for (Cell cell : design.getCells()) {
+			if (!cell.isPort()) {
+				if (cell.isMacro() && cell.isPlaced()) {
+					for (Cell internalCell : cell.getInternalCells()) {
+						uniqueLibraryCells.add(internalCell.getLibCell());
+					}
+				} else {
+					// If the macro cell has not been placed, include the full macro in the EDIF.
+					// If the full macro for unplaced LUTRAMs is not included in the EDIF, Vivado will
+					// be unable to place them.
+					uniqueLibraryCells.add(cell.getLibCell());
+				}
+			}
 		}
-		
+
 		return uniqueLibraryCells;
 	}
-	
+
 	/*
 	 * Creates the top level EDIF cell that contains the design
 	 */
@@ -565,22 +577,32 @@ public final class EdifInterface {
 		topLevelCell.setInterface(cellInterface);
 		
 		// create the cell instances
-		Iterator<Cell> cellIt = design.getLeafCells().iterator();
-		while (cellIt.hasNext()) {
-			Cell cell = cellIt.next();
-			
+		for (Cell cell : design.getCells()) {
 			if (cell.isPort())
 				continue;
-			
-			EdifCell edifLibCell = cellMap.get(cell.getLibCell());
-			topLevelCell.addSubCell( createEdifCellInstance(cell, topLevelCell, edifLibCell) );
+
+			if (cell.isMacro() && cell.isPlaced()) {
+				if (!suppressInfoMessages)
+					System.out.println("[Info] Macro cell " + cell.getName() + " is placed and will be flattened.");
+
+				for (Cell internalCell : cell.getInternalCells()) {
+					EdifCell edifLibCell = cellMap.get(internalCell.getLibCell());
+					topLevelCell.addSubCell(createEdifCellInstance(internalCell, topLevelCell, edifLibCell));
+				}
+			} else {
+				if (cell.isMacro() && !suppressInfoMessages)
+					System.out.println("[Info] Macro cell " + cell.getName() + " is unplaced and will NOT be flattened.");
+
+				EdifCell edifLibCell = cellMap.get(cell.getLibCell());
+				topLevelCell.addSubCell(createEdifCellInstance(cell, topLevelCell, edifLibCell));
+			}
 		}
 		
 		// create the net instances
 		for (CellNet net : design.getNets()) {
 		 	topLevelCell.addNet(createEdifNet(net, topLevelCell, portInfoMap));
 		}
-			
+
 		topLevelCell.addPropertyList(createEdifPropertyList(design.getProperties()));
 		return topLevelCell; 
 	}
@@ -607,7 +629,7 @@ public final class EdifInterface {
 					int busMember = Integer.parseInt(m.group(2));
 					PortInformation portInfo = portMap.getOrDefault(portName, new PortInformation(portName, direction, false, busMember));
 					portInfo.addPort(busMember);
-					portMap.computeIfAbsent(portName, k -> portInfo);
+					portMap.putIfAbsent(portName, portInfo);
 					portInfoMap.put(cell, portInfo);
 				} 
 				else {
@@ -622,7 +644,7 @@ public final class EdifInterface {
 			String portName = entry.getKey();
 			PortInformation portInfo = entry.getValue();
 			
-			EdifNameable edifPortName = null;
+			EdifNameable edifPortName;
 			
 			if (portInfo.isSingleBitPort()) {
 				// some single-bit ports can be names like port[0]...which matches the bus pattern for port names...
@@ -663,16 +685,16 @@ public final class EdifInterface {
 	 */
 	private static EdifNet createEdifNet(CellNet cellNet, EdifCell edifParentCell, Map<Cell, PortInformation> portInfoMap) {
 		EdifNet edifNet = new EdifNet(createEdifNameable(cellNet.getName()), edifParentCell);
-				
+
 		// create the port references for the edif net
-		for (CellPin cellPin : cellNet.getPins()) {
-			
+		for (CellPin cellPin : getEdifNetPins(cellNet)) {
+
 			if (cellPin.isPseudoPin()) {
 				continue;
 			}
 						
 			Cell parentCell = cellPin.getCell();
-			
+
 			EdifPortRef portRef = parentCell.isPort() ?
 									createEdifPortRefFromPort(parentCell, edifParentCell, edifNet, portInfoMap.get(parentCell).getMin()) : 
 									createEdifPortRefFromCellPin(cellPin, edifParentCell, edifNet) ;
@@ -712,8 +734,8 @@ public final class EdifInterface {
 	 * to the connection.
 	 */
 	private static EdifPortRef createEdifPortRefFromCellPin(CellPin cellPin, EdifCell edifParent, EdifNet edifNet) {
-		
 		EdifCellInstance cellInstance = edifParent.getCellInstance(getEdifName(cellPin.getCell().getName()));
+
 		EdifCell libCell = cellInstance.getCellType();
 		
 		String[] toks = cellPin.getName().split("\\["); 
@@ -742,18 +764,19 @@ public final class EdifInterface {
 		for (Property prop : properties) {
 			// The key and value of the property need sensible toString() methods when exporting to EDIF
 			// this function is for creating properties for printing only!
-			// TODO: make sure to inform the user of this 
-			if (prop.getType().equals(PropertyType.EDIF)){/**Only get PropertyType EDIF when creating EDIF propertyList*/
+			// TODO: make sure to inform the user of this
+			// Only get PropertyType EDIF when creating EDIF propertyList
+			if (prop.getType().equals(PropertyType.EDIF)){
 				edu.byu.ece.edif.core.Property edifProperty;
 
 				Object value = prop.getValue();
 
 				if (value instanceof Boolean) {
-					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey().toString(), (Boolean) value);
+					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey(), (Boolean) value);
 				} else if (value instanceof Integer) {
-					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey().toString(), (Integer) value);
+					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey(), (Integer) value);
 				} else {
-					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey().toString(), prop.getValue().toString());
+					edifProperty = new edu.byu.ece.edif.core.Property(prop.getKey(), prop.getValue().toString());
 				}
 
 				edifProperties.addProperty(edifProperty);
@@ -841,4 +864,20 @@ public final class EdifInterface {
 		
 		return PortDirection.isInputPort(portCell) ? EdifPort.IN : EdifPort.OUT; 
 	}
+
+
+	/**
+	 * Returns the cell pins of a net, returning macro cell pins in place of
+	 * internal cell pins if the corresponding internal cell has not been placed.
+	 * @return
+	 */
+	private static Collection<CellPin> getEdifNetPins(CellNet net) {
+		return net.getPins().stream().map(p -> {
+			if (p.isInternal() && !p.getCell().isPlaced())
+				return p.getExternalPin();
+			return p;
+		})
+				.collect(Collectors.toSet());
+	}
+
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/PortInformation.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/PortInformation.java
@@ -20,7 +20,7 @@
 package edu.byu.ece.rapidSmith.interfaces.vivado;
 
 /**
- *	This class is used in the {@link EdifInterface} class to 
+ *	This class is used in the {@link VivadoEdifInterface} class to
  *	consolidate port information together. For bus ports,
  *	it keeps track of the minimum and maximum bus index for the port.
  */

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoEdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoEdifInterface.java
@@ -27,7 +27,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import edu.byu.ece.edif.core.BooleanTypedValue;
 import edu.byu.ece.edif.core.EdifCell;
 import edu.byu.ece.edif.core.EdifCellInstance;
 import edu.byu.ece.edif.core.EdifCellInterface;
@@ -42,28 +41,26 @@ import edu.byu.ece.edif.core.EdifPort;
 import edu.byu.ece.edif.core.EdifPortRef;
 import edu.byu.ece.edif.core.EdifPrintWriter;
 import edu.byu.ece.edif.core.EdifSingleBitPort;
-import edu.byu.ece.edif.core.EdifTypedValue;
-import edu.byu.ece.edif.core.IntegerTypedValue;
 import edu.byu.ece.edif.core.InvalidEdifNameException;
 import edu.byu.ece.edif.core.PropertyList;
 import edu.byu.ece.edif.core.RenamedObject;
 import edu.byu.ece.edif.core.StringTypedValue;
 import edu.byu.ece.edif.util.parse.EdifParser;
 import edu.byu.ece.edif.util.parse.ParseException;
-import edu.byu.ece.rapidSmith.design.NetType;
 import edu.byu.ece.rapidSmith.design.subsite.Cell;
 import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
 import edu.byu.ece.rapidSmith.design.subsite.CellLibrary;
 import edu.byu.ece.rapidSmith.design.subsite.CellNet;
 import edu.byu.ece.rapidSmith.design.subsite.CellPin;
 import edu.byu.ece.rapidSmith.design.subsite.LibraryCell;
-import edu.byu.ece.rapidSmith.design.subsite.LibraryMacro;
 import edu.byu.ece.rapidSmith.design.subsite.LibraryPin;
 import edu.byu.ece.rapidSmith.design.subsite.Property;
 import edu.byu.ece.rapidSmith.design.subsite.PropertyType;
 import edu.byu.ece.rapidSmith.device.PinDirection;
 import edu.byu.ece.rapidSmith.device.PortDirection;
+import edu.byu.ece.rapidSmith.interfaces.AbstractEdifInterface;
 import edu.byu.ece.rapidSmith.util.Exceptions;
+
 
 /**
  * This class is used to interface RapidSmith with EDIF files generated from Vivado.
@@ -75,31 +72,14 @@ import edu.byu.ece.rapidSmith.util.Exceptions;
  * Currently, the EdifInterace class only supports EDIF files created from fully flattened Vivado designs.
  * All BYU EDIF exceptions are wrapped into RapidSmith2 exceptions before being thrown. 
  */
-public final class EdifInterface {
+public final class VivadoEdifInterface extends AbstractEdifInterface {
 
-	private static boolean suppressWarnings = false;
-	private static boolean suppressInfoMessages = false;
-
-	/**
-	 * Suppress non-critical warnings while parsing an EDIF file. 
-	 */
-	public static void suppressWarnings(boolean suppress) {
-		suppressWarnings = suppress;
-	}
-
-	/**
-	 * Suppress info messages while parsing an EDIF file.
-	 */
-	public static void suppressInfoMessages(boolean suppress) {
-		suppressInfoMessages = suppress;
-	}
-	
 	/* ********************
 	 * 	 Import Section
 	 *********************/
-	private static Pattern busNamePattern; 
-	
-	static 
+	private static Pattern busNamePattern;
+
+	static
 	{
 		busNamePattern = Pattern.compile("(.*)\\[.+:(.+)\\]");
 	}
@@ -111,13 +91,12 @@ public final class EdifInterface {
 	 * @param libCells A Cell library for a specific Xilinx part
 	 * 
 	 * @return The RapidSmith2 representation of the EDIF netlist
-	 * @throws FileNotFoundException
 	 */
-	public static CellDesign parseEdif(String edifFile, CellLibrary libCells) {
+	public CellDesign parseEdif(String edifFile, CellLibrary libCells, String partName) {
 		
 		List<CellNet> vccNets = new ArrayList<>();
 		List<CellNet> gndNets = new ArrayList<>();
-		Map<EdifPort, Integer> portOffsetMap = new HashMap<EdifPort, Integer>();
+		Map<EdifPort, Integer> portOffsetMap = new HashMap<>();
 
 		try {		
 			// parse edif into the BYU edif tools data structures
@@ -125,7 +104,12 @@ public final class EdifInterface {
 			EdifCell topLevelCell = top.getTopCell();
 			
 			// create RS2 cell design
-			String partName = ((StringTypedValue)top.getTopDesign().getProperty("part").getValue()).getStringValue();
+			String edifPartName = ((StringTypedValue)top.getTopDesign().getProperty("part").getValue()).getStringValue();
+
+			if (!suppressWarnings && !partName.equals(edifPartName)) {
+				System.err.println("[Warning] Part name in EDIF, " + edifPartName + ", does not match part name in design.info, " + partName);
+			}
+
 			CellDesign design= new CellDesign(top.getTopDesign().getName(), partName);	
 			design.getProperties().updateAll(createCellProperties(topLevelCell.getPropertyList()));
 			
@@ -145,7 +129,7 @@ public final class EdifInterface {
 	/*
 	 * Converts EDIF top level ports to equivalent RapidSmith port cells and adds them to the design
 	 */
-	private static void processTopLevelEdifPorts (CellDesign design, EdifCellInterface topInterface, CellLibrary libCells, Map<EdifPort, Integer> portOffsetMap) {
+	private void processTopLevelEdifPorts (CellDesign design, EdifCellInterface topInterface, CellLibrary libCells, Map<EdifPort, Integer> portOffsetMap) {
 		
 		for ( EdifPort port : topInterface.getPortList() ) {
 			
@@ -190,292 +174,7 @@ public final class EdifInterface {
 			}
 		}
 	}
-		
-	/*
-	 * Converts EDIF cell instances to equivalent RapidSmith cells and adds them to the design
-	 */
-	private static void processEdifCells(CellDesign design, Collection<EdifCellInstance> edifCellInstances, CellLibrary libCells, List<CellNet> vccNets, List<CellNet> gndNets) {
-		// TODO: think about throwing an error or warning here
-		if (edifCellInstances == null || edifCellInstances.size() == 0) {
-			if (!suppressWarnings) {
-				System.err.println("[Warning] No cells found in the edif netlist");
-			}
-			return;
-		}
-		
-		// create equivalent RS2 cells from the edif cell instances
-		for(EdifCellInstance eci : edifCellInstances) {
-			// create the corresponding RS2 cell
-			LibraryCell lcType = libCells.get(eci.getType());
-			if (lcType == null) {
-				throw new Exceptions.ParseException("Unable to find library cell of type: " + eci.getType());
-			}
-			
-			// Check for naming conflicts and rename cells as required...this should not be necessary for designs
-			// synthesized and implemented in Vivado, but if the netlist is manipulated by an external tool,
-			// this can happen
-			if (design.hasCell(eci.getOldName())) {
-				handleNamingConflict(design, design.getCell(eci.getOldName()));
-			}
-			
-			Cell newcell = design.addCell(new Cell(eci.getOldName(), lcType));
-			
-			// Add properties to the cell 
-			newcell.getProperties().updateAll(createCellProperties(eci.getPropertyList()));
-			
-			// look for internal macro nets
-			if (newcell.isMacro()) {
-				for (CellNet net : newcell.getInternalNets()) {
-					if (net.isVCCNet()) {
-						vccNets.add(net);
-					}
-					else if (net.isGNDNet()) {
-						gndNets.add(net);
-					}
-				}
-			}
-		}
-	}
-	
-	/**
-	 * Some EDIF netlists from Vivado can have identical port and cell names. This function renames the ports
-	 * so that there is no naming conflict in RapidSmith. 
-	 * 
-	 * @param design CellDesign
-	 * @param cell Cell to rename (should be a port cell)
-	 */
-	private static void handleNamingConflict (CellDesign design, Cell cell) {
-		assert cell.isPort() : "Conflicting cell names should only happen with Port cells: " + cell.getName();
-		
-		// print a warning to the user
-		if (!suppressWarnings) {
-			System.err.println("[Warning] A top-level port and another cell in the netlist have identical names: " + cell.getName() 
-			              + ". The port cell will be renamed to " + cell.getName() + "_rsport");
-		}
-		
-		// update the name of the cell 
-		design.removeCell(cell);
-		Cell newPortCell = new Cell(cell.getName() + "_rsport", cell.getLibCell());
-		design.addCell(newPortCell);
-	}
-	
-	/*
-	 * Converts EDIF nets to equivalent RapidSmith nets and adds them to the design
-	 */
-	private static void processEdifNets(CellDesign design, Collection<EdifNet> edifNets, List<CellNet> vccNets, List<CellNet> gndNets, Map<EdifPort, Integer> portOffsetMap) {
-		 
-		if (edifNets == null || edifNets.size() == 0) {
-			if (!suppressWarnings) {
-				System.err.println("[Warning] No nets found in the edif netlist");
-			}
-			return;
-		}
-		
-		// Go through the cell's nets and hook up inputs and outputs 
-		for(EdifNet net : edifNets) {
-			
-			//create a new net
-			CellNet cn = new CellNet(net.getOldName(), NetType.WIRE); 
-			
-			// Add all the source and sink connections to the net
-			//Collection<EdifPortRef> sources = net.getSourcePortRefs(false, true);
-			
-			// process all net connections
-			processNetConnections(net.getPortRefList(), design, cn, portOffsetMap);
-			
-			//report a warning if no sources on a net are found
-			if (cn.getAllSourcePins().size() == 0) {
-				if (!suppressWarnings) {
-					System.err.println("[Warning] No source for net " + net.getOldName());
-				}
-			}
-						
-			// Add the net to the design if is is NOT a static net.
-			// Otherwise, store it for later use (will collapse later)
-			if (cn.isVCCNet()) {
-				vccNets.add(cn);
-			}
-			else if (cn.isGNDNet()) {
-				gndNets.add(cn);
-			}
-			else {
-				design.addNet(cn);
-			}
-			
-			cn.getProperties().updateAll(createCellProperties(net.getPropertyList()));
-		}
-	}
-	
-	/*
-	 * Builds the connections of CellNet based on the specified EDIF port references. Returns true
-	 * if the given net is attached to a top-level port, false otherwise
-	 * 
-	 * TODO: update this once top-level ports are added
-	 */
-	private static void processNetConnections(Collection<EdifPortRef> portRefs, CellDesign design, CellNet net, Map<EdifPort, Integer> portOffsetMap) {
-			
-		for (EdifPortRef portRef: portRefs) {  
-			
-			EdifPort port = portRef.getPort(); 
-			
-			// Connects to a top-level port
-			if (portRef.isTopLevelPortRef()) {
-								
-				String portname = portRef.isSingleBitPortRef() ? port.getOldName() : 
-				 				  String.format("%s[%d]", getPortNamePrefix(port.getOldName()), reverseBusIndex(port.getWidth(), portRef.getBusMember(), portOffsetMap.get(port)));
-				
-				Cell portCell = design.getCell(portname);
-				
-				if (portCell == null) {
-					throw new Exceptions.ParseException("Port Cell " + portname + " does not exist in the design!");
-				}
-				else if (!portCell.isPort()) {
-					portCell = design.getCell(portname + "_rsport");
-				}
-				
-				net.connectToPin(portCell.getPin("PAD"));
-								
-				continue; 
-			}
-			
-			Cell node = design.getCell(portRef.getCellInstance().getOldName()); 
-			if (node == null) {
-				throw new Exceptions.ParseException("Cell: " + portRef.getCellInstance().getOldName()  + " does not exist in the design!");
-			}
-			
-			int busOffset = 0;
-			if (node.isMacro()) {
-				LibraryMacro macro = (LibraryMacro)node.getLibCell(); 
-				busOffset = macro.getPinOffset(port.getName());
-			}
-			
-			// Connects to a cell pin
-			// TODO: take a closer look at this...I am using the edif name of a cell pin name which should be ok, but be aware
-			String pinname = portRef.isSingleBitPortRef() ? port.getName() 
-					 : String.format("%s[%d]", port.getName(), reverseBusIndex(port.getWidth(), portRef.getBusMember(), busOffset));
-			
-			// Mark GND and VCC nets 
-			if (node.isVccSource()) {
-				net.setType(NetType.VCC);
-			}
-			else if (node.isGndSource()) {
-				net.setType(NetType.GND);
-			}
-			
-			net.connectToPin(node.getPin(pinname));						
-		}		
-	}
-	
-	/*
-	 * Vivado ports that are buses are named portName[15:0]
-	 * This function will return the "portName" portion of the bus name
-	 */
-	private static String getPortNamePrefix(String portName) {
-		
-		int bracketIndex = portName.lastIndexOf("[");
-		return bracketIndex == -1 ? portName : portName.substring(0, bracketIndex);
-	}
-		
-	/*
-	 * Creates a list of RapidSmith cell properties from an EDIF property list
-	 */
-	private static List<Property> createCellProperties(PropertyList edifPropertyList) {
-		List<Property> cellProperties = new ArrayList<>();
-		
-		if (edifPropertyList != null) {
-			for (String keyName : edifPropertyList.keySet()) {
-				edu.byu.ece.edif.core.Property property = edifPropertyList.getProperty(keyName);
-				Property prop = new Property(property.getName(), PropertyType.EDIF, getValueFromEdifType(property.getValue()));
-				cellProperties.add(prop);
-			}
-		}
-		
-		return cellProperties;
-	}
-	
-	/*
-	 * Converts an EdifTypedValue to the corresponding native Java type
-	 */
-	private static Object getValueFromEdifType(EdifTypedValue typedValue) {
-		
-		Object value;
-		if (typedValue instanceof IntegerTypedValue) {
-			value = ((IntegerTypedValue)typedValue).getIntegerValue();
-		}
-		else if (typedValue instanceof BooleanTypedValue) {
-			value = ((BooleanTypedValue)typedValue).getBooleanValue();
-		}
-		else  { // default is string type
-			value = ((StringTypedValue)typedValue).getStringValue();
-		}
-		return value;
-	}
-	
-	/*
-	 * Because EDIF files reverse the index of bus members, this function
-	 * is used to get the original index of a port into a bus.  
-	 */
-	private static int reverseBusIndex(int width, int busMember, int offset) {
-		return width - 1 - busMember + offset;
-	}
-	
-	private static void collapseStaticNets(CellDesign design, CellLibrary libCells, List<CellNet> vccNets, List<CellNet> gndNets) {
-		
-		// Create new global VCC/GND cells and nets
-		Cell globalVCC = new Cell("RapidSmithGlobalVCC", libCells.getVccSource());
-		Cell globalGND = new Cell("RapidSmithGlobalGND", libCells.getGndSource());		
-		CellNet globalVCCNet = new CellNet("RapidSmithGlobalVCCNet", NetType.VCC);
-		CellNet globalGNDNet = new CellNet("RapidSmithGlobalGNDNet", NetType.GND);
-		
-		// Connect the global sources to the global nets
-		globalVCCNet.connectToPin(globalVCC.getOutputPins().iterator().next());
-		globalGNDNet.connectToPin(globalGND.getOutputPins().iterator().next());
-		
-		// Add all VCC/GND sink pins to the global nets
-		for(CellNet net : vccNets) {
-			transferSinkPins(net, globalVCCNet);
-		}
-		
-		for(CellNet net : gndNets) {
-			transferSinkPins(net, globalGNDNet);
-		}
-			
-		// Remove the old VCC/GND cells from the list
-		List<Cell> cellsToRemove = new ArrayList<>();
-		for (Cell cell : design.getCells()) {
-			if (cell.isVccSource() || cell.isGndSource()) {
-				cellsToRemove.add(cell);
-			}
-		}
-		cellsToRemove.forEach(design::removeCell);
-				
-		// Add the new master cells/nets to the design
-		design.addCell(globalVCC);
-		design.addNet(globalVCCNet);
-		design.addCell(globalGND);
-		design.addNet(globalGNDNet);
-		
-		// For macro pins tied to power or ground, make them point to the appropriate global static net
-		for (Cell c : design.getCells()) {
-			for (CellPin cp : c.getPins()) {
-				if (cp.getNet()!= null) {
-					if (cp.getNet() != globalGNDNet && cp.getNet().getType() == NetType.GND) 
-						cp.setMacroPinToGlobalNet(globalGNDNet);
-					else if (cp.getNet() != globalVCCNet && cp.getNet().getType() == NetType.VCC) 
-						cp.setMacroPinToGlobalNet(globalVCCNet);
-				}
-			}
-		}
 
-	}
-	
-	private static void transferSinkPins(CellNet oldNet, CellNet newNet) {
-		Collection<CellPin> sinkPins = oldNet.getSinkPins();
-		oldNet.detachNet();
-		oldNet.unrouteFull();
-		newNet.connectToPins(sinkPins);
-	}
-	
 	/* *********************
 	 *    Export Section
 	 ***********************/
@@ -487,7 +186,8 @@ public final class EdifInterface {
 	 * @param design RapidSmith design to convert to EDIF
 	 * @throws IOException
 	 */
-	public static void writeEdif(String edifOutputFile, CellDesign design) throws IOException {
+	@Override
+	public void writeEdif(String edifOutputFile, CellDesign design) throws IOException {
 		
 		try {
 			// TODO: copy old edif environment properties into new edif environment properties
@@ -537,7 +237,7 @@ public final class EdifInterface {
 	/*
 	 * Returns a hashset of all unique library cells in a given design
 	 */
-	private static HashSet<LibraryCell> getUniqueLibraryCellsInDesign(CellDesign design) {
+	private HashSet<LibraryCell> getUniqueLibraryCellsInDesign(CellDesign design) {
 		HashSet<LibraryCell> uniqueLibraryCells = new HashSet<>();
 
 		for (Cell cell : design.getCells()) {
@@ -561,7 +261,7 @@ public final class EdifInterface {
 	/*
 	 * Creates the top level EDIF cell that contains the design
 	 */
-	private static EdifCell createEdifTopLevelCell(CellDesign design, EdifLibrary library, HashMap<LibraryCell, EdifCell> cellMap) throws EdifNameConflictException, InvalidEdifNameException {	
+	private EdifCell createEdifTopLevelCell(CellDesign design, EdifLibrary library, HashMap<LibraryCell, EdifCell> cellMap) throws EdifNameConflictException, InvalidEdifNameException {
 		
 		EdifCell topLevelCell = new EdifCell(library, createEdifNameable(design.getName()));
 		
@@ -607,7 +307,7 @@ public final class EdifInterface {
 	 * 
 	 * TODO: This is only guaranteed to work with netlists imported from Vivado. 
 	 */
-	private static EdifCellInterface createTopLevelInterface(CellDesign design, EdifCell topLevelEdifCell, Map<Cell, PortInformation> portInfoMap) throws EdifNameConflictException, InvalidEdifNameException {
+	private EdifCellInterface createTopLevelInterface(CellDesign design, EdifCell topLevelEdifCell, Map<Cell, PortInformation> portInfoMap) throws EdifNameConflictException, InvalidEdifNameException {
 		
 		EdifCellInterface cellInterface = new EdifCellInterface(topLevelEdifCell);
 		Pattern portNamePattern = Pattern.compile("(.*)\\[(.*)\\]");
@@ -664,7 +364,7 @@ public final class EdifInterface {
 	/*
 	 * Creates an EDIF cell instance from a corresponding RapidSmith cell
 	 */
-	private static EdifCellInstance createEdifCellInstance(Cell cell, EdifCell parent, EdifCell edifLibCell) {
+	private EdifCellInstance createEdifCellInstance(Cell cell, EdifCell parent, EdifCell edifLibCell) {
 		
 		Objects.requireNonNull(edifLibCell);
 		EdifCellInstance cellInstance = new EdifCellInstance(createEdifNameable(cell.getName()), parent, edifLibCell);
@@ -678,7 +378,7 @@ public final class EdifInterface {
 	/*
 	 * Creates an EDIF net from a corresponding RapidSmith net
 	 */
-	private static EdifNet createEdifNet(CellNet cellNet, EdifCell edifParentCell, Map<Cell, PortInformation> portInfoMap) {
+	private EdifNet createEdifNet(CellNet cellNet, EdifCell edifParentCell, Map<Cell, PortInformation> portInfoMap) {
 		EdifNet edifNet = new EdifNet(createEdifNameable(cellNet.getName()), edifParentCell);
 
 		// create the port references for the edif net
@@ -703,7 +403,7 @@ public final class EdifInterface {
 	/*
 	 * Creates a port reference (connection) for an EDIF net from a top-level port cell.
 	 */
-	private static EdifPortRef createEdifPortRefFromPort(Cell port, EdifCell edifParent, EdifNet edifNet, int portOffset) {
+	private EdifPortRef createEdifPortRefFromPort(Cell port, EdifCell edifParent, EdifNet edifNet, int portOffset) {
 		// Split on the last '['
 		String[] toks = port.getName().split("\\[(?!.*\\[)");
 		
@@ -728,7 +428,7 @@ public final class EdifInterface {
 	 * This is different than the port implementation because it needs to add a cell instance
 	 * to the connection.
 	 */
-	private static EdifPortRef createEdifPortRefFromCellPin(CellPin cellPin, EdifCell edifParent, EdifNet edifNet) {
+	private EdifPortRef createEdifPortRefFromCellPin(CellPin cellPin, EdifCell edifParent, EdifNet edifNet) {
 		EdifCellInstance cellInstance = edifParent.getCellInstance(getEdifName(cellPin.getCell().getName()));
 
 		EdifCell libCell = cellInstance.getCellType();
@@ -753,7 +453,7 @@ public final class EdifInterface {
 	/*
 	 * Converts a collection of RapidSmith properties to an EDIF property list
 	 */
-	private static PropertyList createEdifPropertyList (edu.byu.ece.rapidSmith.design.subsite.PropertyList properties) {
+	private PropertyList createEdifPropertyList(edu.byu.ece.rapidSmith.design.subsite.PropertyList properties) {
 		PropertyList edifProperties = new PropertyList();
 		
 		for (Property prop : properties) {
@@ -783,7 +483,7 @@ public final class EdifInterface {
 	/*
 	 * Creates an EDIF cell that corresponds to a RapidSmith library cell
 	 */
-	private static EdifCell createEdifLibraryCell(LibraryCell cell, EdifLibrary library) throws EdifNameConflictException, InvalidEdifNameException {
+	private EdifCell createEdifLibraryCell(LibraryCell cell, EdifLibrary library) throws EdifNameConflictException, InvalidEdifNameException {
 		// this will print a cell with the "view PRIM" ... vivado prints them with "view netlist" this shouldn't be a problem
 		EdifCell edifCell = new EdifCell(library, createEdifNameable(cell.getName()), true);
 		
@@ -820,7 +520,7 @@ public final class EdifInterface {
 	/*
 	 * Creates a valid EDIF nameable for the specified input
 	 */
-	private static EdifNameable createEdifNameable(String name) {
+	private EdifNameable createEdifNameable(String name) {
 		
 		return RenamedObject.createValidEdifNameable(name);
 	}
@@ -828,14 +528,14 @@ public final class EdifInterface {
 	/*
 	 * Returns the valid EDIF name for the specified input
 	 */
-	private static String getEdifName(String originalName) {
+	private String getEdifName(String originalName) {
 		return RenamedObject.createValidEdifString(originalName);
 	}
 	
 	/*
 	 * Converts a RapidSmith pin direction to an EDIF pin direction
 	 */
-	private static int getEdifPinDirection(PinDirection direction) {	
+	private int getEdifPinDirection(PinDirection direction) {
 		switch(direction) {
 			case IN:
 				return EdifPort.IN;
@@ -852,7 +552,7 @@ public final class EdifInterface {
 	 * Returns the corresponding EDIF port direction of a RapidSmith
 	 * port cell.
 	 */
-	private static int getEdifPinDirection(Cell portCell) {		
+	private int getEdifPinDirection(Cell portCell) {
 		if (PortDirection.isInoutPort(portCell)) {
 			return EdifPort.INOUT;
 		}
@@ -866,7 +566,7 @@ public final class EdifInterface {
 	 * internal cell pins if the corresponding internal cell has not been placed.
 	 * @return
 	 */
-	private static Collection<CellPin> getEdifExportNetPins(CellNet net) {
+	private Collection<CellPin> getEdifExportNetPins(CellNet net) {
 		return net.getPins().stream().map(p -> {
 			if (p.isInternal() && !p.getCell().isPlaced())
 				return p.getExternalPin();
@@ -878,7 +578,7 @@ public final class EdifInterface {
 	 * Returns a collection of external {@link CellNet}s and internal nets for placed macro cells
 	 * that are currently in the design.
 	 */
-	private static Collection<CellNet> getEdifExportNets(CellDesign design) {
+	private Collection<CellNet> getEdifExportNets(CellDesign design) {
 		// Only include internal nets for macro cells that are placed.
 		Collection<CellNet> nets = design.getNets().stream()
 				.filter(n -> !n.isInternal()).collect(Collectors.toList());

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoEdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoEdifInterface.java
@@ -61,7 +61,6 @@ import edu.byu.ece.rapidSmith.device.PortDirection;
 import edu.byu.ece.rapidSmith.interfaces.AbstractEdifInterface;
 import edu.byu.ece.rapidSmith.util.Exceptions;
 
-
 /**
  * This class is used to interface RapidSmith with EDIF files generated from Vivado.
  * It is capable of: <br>  
@@ -125,9 +124,13 @@ public final class VivadoEdifInterface extends AbstractEdifInterface {
 			throw new Exceptions.ParseException(e);
 		}
 	}
-	
-	/*
+
+	/**
 	 * Converts EDIF top level ports to equivalent RapidSmith port cells and adds them to the design
+	 * @param design
+	 * @param topInterface
+	 * @param libCells
+	 * @param portOffsetMap
 	 */
 	private void processTopLevelEdifPorts (CellDesign design, EdifCellInterface topInterface, CellLibrary libCells, Map<EdifPort, Integer> portOffsetMap) {
 		
@@ -233,9 +236,12 @@ public final class VivadoEdifInterface extends AbstractEdifInterface {
 			throw new AssertionError(e);
 		}
 	}
-	
-	/*
+
+	/**
 	 * Returns a hashset of all unique library cells in a given design
+	 *
+	 * @param design
+	 * @return
 	 */
 	private HashSet<LibraryCell> getUniqueLibraryCellsInDesign(CellDesign design) {
 		HashSet<LibraryCell> uniqueLibraryCells = new HashSet<>();
@@ -258,8 +264,15 @@ public final class VivadoEdifInterface extends AbstractEdifInterface {
 		return uniqueLibraryCells;
 	}
 
-	/*
+	/**
 	 * Creates the top level EDIF cell that contains the design
+	 *
+	 * @param design
+	 * @param library
+	 * @param cellMap
+	 * @return
+	 * @throws EdifNameConflictException
+	 * @throws InvalidEdifNameException
 	 */
 	private EdifCell createEdifTopLevelCell(CellDesign design, EdifLibrary library, HashMap<LibraryCell, EdifCell> cellMap) throws EdifNameConflictException, InvalidEdifNameException {
 		
@@ -301,11 +314,17 @@ public final class VivadoEdifInterface extends AbstractEdifInterface {
 		topLevelCell.addPropertyList(createEdifPropertyList(design.getProperties()));
 		return topLevelCell; 
 	}
-	
-	/*
+
+	/**
 	 * Creates the EDIF interface for the top level cell
-	 * 
-	 * TODO: This is only guaranteed to work with netlists imported from Vivado. 
+	 * TODO: This is only guaranteed to work with netlists imported from Vivado.
+	 *
+	 * @param design
+	 * @param topLevelEdifCell
+	 * @param portInfoMap
+	 * @return
+	 * @throws EdifNameConflictException
+	 * @throws InvalidEdifNameException
 	 */
 	private EdifCellInterface createTopLevelInterface(CellDesign design, EdifCell topLevelEdifCell, Map<Cell, PortInformation> portInfoMap) throws EdifNameConflictException, InvalidEdifNameException {
 		
@@ -360,9 +379,14 @@ public final class VivadoEdifInterface extends AbstractEdifInterface {
 				
 		return cellInterface;
 	}
-	
-	/*
+
+	/**
 	 * Creates an EDIF cell instance from a corresponding RapidSmith cell
+	 *
+	 * @param cell
+	 * @param parent
+	 * @param edifLibCell
+	 * @return
 	 */
 	private EdifCellInstance createEdifCellInstance(Cell cell, EdifCell parent, EdifCell edifLibCell) {
 		
@@ -374,9 +398,14 @@ public final class VivadoEdifInterface extends AbstractEdifInterface {
 				
 		return cellInstance;
 	}
-	
-	/*
+
+	/**
 	 * Creates an EDIF net from a corresponding RapidSmith net
+	 *
+	 * @param cellNet
+	 * @param edifParentCell
+	 * @param portInfoMap
+	 * @return
 	 */
 	private EdifNet createEdifNet(CellNet cellNet, EdifCell edifParentCell, Map<Cell, PortInformation> portInfoMap) {
 		EdifNet edifNet = new EdifNet(createEdifNameable(cellNet.getName()), edifParentCell);
@@ -399,9 +428,15 @@ public final class VivadoEdifInterface extends AbstractEdifInterface {
 					
 		return edifNet;
 	}
-	
-	/*
+
+	/**
 	 * Creates a port reference (connection) for an EDIF net from a top-level port cell.
+	 *
+	 * @param port
+	 * @param edifParent
+	 * @param edifNet
+	 * @param portOffset
+	 * @return
 	 */
 	private EdifPortRef createEdifPortRefFromPort(Cell port, EdifCell edifParent, EdifNet edifNet, int portOffset) {
 		// Split on the last '['
@@ -422,11 +457,16 @@ public final class VivadoEdifInterface extends AbstractEdifInterface {
 		EdifSingleBitPort singlePort = new EdifSingleBitPort(edifPort, portIndex);
 		return new EdifPortRef(edifNet, singlePort, null);	
 	}
-	
-	/*
-	 * Creates a port reference (connection) for an EDIF net from a cell pin. 
+
+	/**
+	 * Creates a port reference (connection) for an EDIF net from a cell pin.
 	 * This is different than the port implementation because it needs to add a cell instance
 	 * to the connection.
+	 *
+	 * @param cellPin
+	 * @param edifParent
+	 * @param edifNet
+	 * @return
 	 */
 	private EdifPortRef createEdifPortRefFromCellPin(CellPin cellPin, EdifCell edifParent, EdifNet edifNet) {
 		EdifCellInstance cellInstance = edifParent.getCellInstance(getEdifName(cellPin.getCell().getName()));

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
@@ -20,18 +20,11 @@
 
 package edu.byu.ece.rapidSmith.interfaces.vivado;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
 
-import edu.byu.ece.edif.core.EdifNameConflictException;
-import edu.byu.ece.edif.core.InvalidEdifNameException;
 import edu.byu.ece.rapidSmith.RSEnvironment;
 import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
 import edu.byu.ece.rapidSmith.design.subsite.CellLibrary;
@@ -56,8 +49,7 @@ public final class VivadoInterface {
 	 * Parses a RSCP generated from Tincr, and creates an equivalent RapidSmith2 design.
 	 * 
 	 * @param rscp Path to the RSCP to import
-	 * @throws InvalidEdifNameException 
-	 * @throws EdifNameConflictException 
+	 * @throws IOException
 	 */
 	public static VivadoCheckpoint loadRSCP (String rscp, boolean storeAdditionalInfo) throws IOException {
 	
@@ -92,7 +84,8 @@ public final class VivadoInterface {
 		
 		// create the RS2 netlist
 		String edifFile = rscpPath.resolve("netlist.edf").toString();
-		CellDesign design = EdifInterface.parseEdif(edifFile, libCells);
+		VivadoEdifInterface vivadoEdifInterface = new VivadoEdifInterface();
+		CellDesign design = vivadoEdifInterface.parseEdif(edifFile, libCells, partName);
 		design.setImplementationMode(mode);
 		
 		// parse the constraints into RapidSmith
@@ -126,8 +119,6 @@ public final class VivadoInterface {
 	 * @param tcpDirectory TINCR checkpoint directory to write XDC files to
 	 * @param design CellDesign to convert to a TINCR checkpoint
 	 * @throws IOException
-	 * @throws InvalidEdifNameException
-	 * @throws EdifNameConflictException
 	 */
 	public static void writeTCP(String tcpDirectory, CellDesign design, Device device, CellLibrary libCells) throws IOException {
 		writeTCP(tcpDirectory, design, device, libCells, false);
@@ -140,8 +131,6 @@ public final class VivadoInterface {
 	 * @param design CellDesign to convert to a TINCR checkpoint
 	 * @param intrasiteRouting Whether to include commands to manually set intrasite routing in Vivado
 	 * @throws IOException
-	 * @throws InvalidEdifNameException 
-	 * @throws EdifNameConflictException 
 	 */
 	public static void writeTCP(String tcpDirectory, CellDesign design, Device device, CellLibrary libCells, boolean intrasiteRouting) throws IOException {
 				
@@ -163,7 +152,8 @@ public final class VivadoInterface {
 		
 		// Write EDIF netlist
 		String edifOut = Paths.get(tcpDirectory, "netlist.edf").toString();
-		EdifInterface.writeEdif(edifOut, design);
+		VivadoEdifInterface vivadoEdifInterface = new VivadoEdifInterface();
+		vivadoEdifInterface.writeEdif(edifOut, design);
 
 		// write constraints.xdc
 		String constraintsOut = Paths.get(tcpDirectory, "constraints.xdc").toString();

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/yosys/YosysEdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/yosys/YosysEdifInterface.java
@@ -1,0 +1,366 @@
+package edu.byu.ece.rapidSmith.interfaces.yosys;
+
+import java.io.FileNotFoundException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import edu.byu.ece.edif.core.*;
+import edu.byu.ece.edif.util.parse.EdifParser;
+import edu.byu.ece.edif.util.parse.ParseException;
+import edu.byu.ece.rapidSmith.design.subsite.*;
+import edu.byu.ece.rapidSmith.interfaces.AbstractEdifInterface;
+import edu.byu.ece.rapidSmith.util.Exceptions;
+
+public class YosysEdifInterface extends AbstractEdifInterface {
+
+	/* ********************
+	 * 	 Import Section
+	 *********************/
+
+	/**
+	 * Gets the XORCY cell connected to a MUXCY cell, if one exists.
+	 * There will be no corresponding XORCY cell if the corresponding O ouput on the CARRY4 doesn't need to be used.
+	 * @param muxCell
+	 * @return the corresponding XORCY cell
+	 */
+	private Cell getXorCell(Cell muxCell) {
+		// The XORCY and MUXCY both share an input pin (MUXCY: S, XORCY: LI)
+		CellNet muxSelectNet = muxCell.getPin("S").getNet();
+
+		Optional<CellPin> xorLiPin = muxSelectNet.getSinkPins().stream()
+				.filter(cellPin -> cellPin.getCell().getType().equals("XORCY"))
+				.filter(cellPin -> cellPin.getName().equals("LI"))
+				.findFirst();
+
+		return xorLiPin.map(CellPin::getCell).orElse(null);
+	}
+
+	/**
+	 * Adds the XORCY cell to the CARRY4 cell.
+	 * @param xorCell
+	 * @param carryCell
+	 * @param carryIndex
+	 * @param chainStart
+	 */
+	private void addXorCellToCarryCell(Cell xorCell, Cell carryCell, int carryIndex, boolean chainStart) {
+		// Connect the input pins
+		for (CellPin cellPin : xorCell.getInputPins()) {
+			CellNet net = cellPin.getNet();
+
+			switch (cellPin.getName()) {
+				case "CI":
+					if (chainStart && carryIndex == 0) {
+						// Disconnect from the XORCY pin
+						net.disconnectFromPin(cellPin);
+
+						// Connect to CARRY4 pin
+						net.connectToPin(carryCell.getPin("CYINIT"));
+					}
+					else if (carryIndex == 0) {
+						// Disconnect from the XORCY pin
+						net.disconnectFromPin(cellPin);
+
+						// Connect to CARRY4 pin
+						net.connectToPin(carryCell.getPin("CI"));
+					}
+					break;
+				case "LI":
+					// Disconnect from the XORCY pin
+					net.disconnectFromPin(cellPin);
+
+					// Connect to CARRY4 pin
+					net.connectToPin(carryCell.getPin("S" + "[" + carryIndex + "]"));
+					break;
+				default:
+					throw new Exceptions.ParseException("XORCY cell " + xorCell.getName() + " has unexpected input pin " + cellPin.getFullName());
+			}
+		}
+
+		// Connect the output pins
+		for (CellPin cellPin : xorCell.getOutputPins()) {
+			CellNet net = cellPin.getNet();
+
+			if (cellPin.getName().equals("O")) {
+				// Disconnect form the XORCY pin
+				net.disconnectFromPin(cellPin);
+
+				// Connect to CARRY4 pin
+				net.connectToPin(carryCell.getPin("O" + "[" + carryIndex + "]"));
+			}
+			else {
+				throw new Exceptions.ParseException("XORCY cell " + xorCell.getName() + " has unexpected input pin " + cellPin.getFullName());
+			}
+		}
+	}
+
+	/**
+	 * Adds the MUXCY cell to the CARRY4 cell.
+	 * @param muxCell
+	 * @param carryCell
+	 * @param carryIndex
+	 * @param chainStart
+	 */
+	private void addMuxCellToCarryCell(Cell muxCell, Cell carryCell, int carryIndex, boolean chainStart) {
+		// Connect the input pins
+		for (CellPin cellPin : muxCell.getInputPins()) {
+			CellNet net = cellPin.getNet();
+			if (net != null) {
+				switch (cellPin.getName()) {
+					case "CI":
+						// Disconnect from the MUXCY pin
+						net.disconnectFromPin(cellPin);
+
+						// Connect to the CARRY4 pin
+						// If this isn't the first MUXCY in a CARRY4, no connection needs to be added
+						if (chainStart && !net.getPins().contains(carryCell.getPin("CYINIT"))) {
+							net.connectToPin(carryCell.getPin("CYINIT"));
+						}
+						else if (carryIndex == 0 && !net.getPins().contains(carryCell.getPin("CI"))) {
+							net.connectToPin(carryCell.getPin("CI"));
+						}
+						break;
+					case "DI":
+						// Disconnect from the MUXCY pin
+						net.disconnectFromPin(cellPin);
+
+						// Connect to the CARRY4 pin
+						net.connectToPin(carryCell.getPin("DI[" + carryIndex + "]"));
+						break;
+					case "S":
+						// Disconnect from the MUXCY pin
+						net.disconnectFromPin(cellPin);
+
+						// Connect to the CARRY4 pin
+						CellPin carryPin = carryCell.getPin("S[" + carryIndex + "]");
+
+						// The net may already be connected to the pin (from adding an XORCY cell)
+						if (!net.getPins().contains(carryPin))
+							net.connectToPin(carryPin);
+						break;
+					default:
+						throw new Exceptions.ParseException("MUXCY cell " + muxCell.getName() + " has unexpected input pin " + cellPin.getFullName());
+				}
+			}
+		}
+
+		// Connect the output pin
+		CellPin muxOutPin = muxCell.getPin("O");
+		CellNet muxOutNet = muxOutPin.getNet();
+
+		for (CellPin pin : muxOutNet.getSinkPins()) {
+			Cell sinkCell = pin.getCell();
+
+			if ("CI".equals(pin.getName())) {
+				if (sinkCell.getType().equals("MUXCY") || sinkCell.getType().equals("XORCY")) {
+					// If it is the last MUXCY in a CARRY4, we need to disconnect the net from the MUXCY source
+					// and connect it to the CARRY4 source.
+					// Since MUXCY and XORCY are driven by this net, we only need to do this once.
+					if (carryIndex == 3 && !muxOutNet.getSourcePin().equals(carryCell.getPin("CO[3]"))) {
+						muxOutNet.disconnectFromPin(muxCell.getPin("O"));
+						muxOutNet.connectToPin(carryCell.getPin("CO[3]"));
+					}
+					else if (carryIndex != 3) {
+						// Disconnect the sink and the MUXCY pin
+						muxOutNet.disconnectFromPin(pin);
+					}
+				}
+				else {
+					throw new Exceptions.ParseException("MUXCY cell " + muxCell.getName() + " has unexpected sink pin " + pin.getFullName());
+				}
+			}
+			// Assume the sink is a LUT pin, etc.
+			else {
+
+				CellNet cyNet = pin.getNet();
+
+				// disconnect from source
+				cyNet.disconnectFromPin(muxOutNet.getSourcePin());
+
+				// Connect to the CARRY4 CO pin.
+				cyNet.connectToPin(carryCell.getPin("CO" + "[" + carryIndex + "]"));
+			}
+		}
+	}
+
+
+	/**
+	 * Builds up a carry chain, creating CARRY4 cells, given a starting MUXCY cell.
+	 * @param muxCell the starting XORCY cell of a CARRY4 chain
+	 */
+	private void buildCarryChain(CellDesign design, CellLibrary libCells, Cell muxCell) {
+		// Get the corresponding XORCY cell if it exists
+		Cell xorCell = getXorCell(muxCell);
+
+		// Mark the start of the carry chain
+		boolean chainStart = true;
+		Cell carryCell = new Cell(muxCell.getName() + "_CARRY4", libCells.get("CARRY4"));
+		int carryIndex = 0;
+
+		// Replace muxCell
+		while (muxCell != null || xorCell != null) {
+
+			// Add the XORCY cell (if it exists) and the MUXCY cell to the CARRY4 cell.
+			if (xorCell != null) {
+				addXorCellToCarryCell(xorCell, carryCell, carryIndex, chainStart);
+				design.removeCell(xorCell);
+				xorCell = null;
+			}
+
+			if (muxCell != null) {
+				// Get a map to the MUXCY/XORCY cells this MUXCY drives
+				Map<String, Cell> sinkCells = muxCell.getPin("O").getNet().getSinkPins().stream()
+						.filter(p -> p.getName().equals("CI"))
+						.collect(Collectors.toMap(p -> p.getCell().getType(), CellPin::getCell));
+
+				addMuxCellToCarryCell(muxCell, carryCell, carryIndex, chainStart);
+				design.removeCell(muxCell);
+
+				muxCell = sinkCells.get("MUXCY");
+				xorCell = sinkCells.get("XORCY");
+			}
+
+			chainStart = false;
+
+			// If the carry chain has ended
+			if (muxCell == null && xorCell == null) {
+				design.addCell(carryCell);
+			}
+			// If we need to make a new CARRY4 cell to continue the chain
+			else if (carryIndex == 3) {
+				design.addCell(carryCell);
+				String carryCellNamePrefix = muxCell != null ? muxCell.getName() : xorCell.getName();
+				carryCell = new Cell(carryCellNamePrefix + "_CARRY4", libCells.get("CARRY4"));
+				carryIndex = 0;
+			}
+			else
+				carryIndex++;
+			}
+
+		}
+
+	/**
+	 * Transform XORCY and MUXCY cells into CARRY4 cells.
+	 * @param design
+	 * @param libCells
+	 */
+	private void transformCarryCells(CellDesign design, CellLibrary libCells) {
+
+		if (!libCells.contains("CARRY4")) {
+			if (!suppressWarnings) {
+				System.err.println("[Warning] Cell library does not contain CARRY4 cells. MUXCY and XORCY cells will not be transformed into CARRY cells.");
+			}
+			return;
+		}
+
+		// Find the beginning of the carry chains in the design.
+		// The carry chains will start with a MUXCY cell whose CI/CYINIT pin is driven by VCC/GND.
+		Collection<Cell> muxInitCells = design.getCells().stream()
+				.filter(cell -> cell.getType().equals("MUXCY"))
+				.filter(cell -> cell.getPin("CI").getNet().isStaticNet())
+				.collect(Collectors.toList());
+
+		for (Cell muxCell : muxInitCells) {
+			buildCarryChain(design, libCells, muxCell);
+		}
+	}
+
+	/**
+	 * Converts EDIF top level ports to equivalent RapidSmith port cells and adds them to the design
+	 * @param design
+	 * @param topInterface
+	 * @param libCells
+	 * @param portOffsetMap
+	 */
+	private void processTopLevelEdifPorts (CellDesign design, EdifCellInterface topInterface, CellLibrary libCells, Map<EdifPort, Integer> portOffsetMap) {
+		for ( EdifPort port : topInterface.getPortList() ) {
+			String libraryPortType;
+
+			if (port.isInOut()) {
+				libraryPortType = "IOPORT";
+			}
+			else if (port.isInput()) {
+				libraryPortType = "IPORT";
+			}
+			else {
+				libraryPortType = "OPORT";
+			}
+
+			// find the port prefix and offset
+			int offset = 0;
+			String portPrefix = port.getOldName();
+			// TODO: For now assume the port offset will always be 0. Revisit once Yosys issue #568 is resolved.
+			if (port.isBus())
+				portOffsetMap.put(port, offset);
+
+			// Create a new RapidSmith cell for each port in the EDIF
+			for (EdifSingleBitPort busMember : port.getSingleBitPortList() ) {
+
+				LibraryCell libCell = libCells.get(libraryPortType);
+
+				String portName = port.isBus() ?
+						String.format("%s[%d]", portPrefix, reverseBusIndex(port.getWidth(), busMember.bitPosition(), offset)) :
+						portPrefix;
+				Cell portCell = new Cell(portName, libCell);
+				design.addCell(portCell);
+			}
+		}
+	}
+
+	@Override
+	public CellDesign parseEdif(String edifFile, CellLibrary libCells, String partName) {
+		return parseEdif(edifFile, libCells, partName, false);
+	}
+
+	/**
+	 * Parses the Edif netlist into a RapidSmith2 CellDesign data structure
+	 *
+	 * @param edifFile Input EDIF file
+	 * @param libCells A Cell library for a specific Xilinx part
+	 * @param partName Name of the part for the design. Needs to be set manually for partial devices when using a netlist
+	 *                 synthesized by Vivado, since the netlist contains the name of the full part.
+	 * @param transformCells Whether or not to transform cells. Only transforms MUXCY, XORCY cells to CARRY4 cells right now.
+	 * @return The RapidSmith2 representation of the EDIF netlist
+	 */
+	public CellDesign parseEdif(String edifFile, CellLibrary libCells, String partName, boolean transformCells) {
+		List<CellNet> vccNets = new ArrayList<>();
+		List<CellNet> gndNets = new ArrayList<>();
+		Map<EdifPort, Integer> portOffsetMap = new HashMap<>();
+
+		try {
+			// parse edif into the BYU edif tools data structures
+			EdifEnvironment top = EdifParser.translate(edifFile);
+			EdifCell topLevelCell = top.getTopCell();
+
+			// create RS2 cell design
+			CellDesign design = new CellDesign(top.getTopDesign().getName(), partName);
+			design.getProperties().updateAll(createCellProperties(topLevelCell.getPropertyList()));
+
+			// add all the cells and nets to the design
+			processTopLevelEdifPorts(design, topLevelCell.getInterface(), libCells, portOffsetMap);
+			processEdifCells(design, topLevelCell.getCellInstanceList(), libCells, vccNets, gndNets);
+			processEdifNets(design, topLevelCell.getNetList(), vccNets, gndNets, portOffsetMap);
+
+			// Transform MUXCY, XORCY cells to CARRY4 cells
+			if (transformCells)
+				transformCarryCells(design, libCells);
+
+			collapseStaticNets(design, libCells, vccNets, gndNets);
+
+			return design;
+		}
+		catch (FileNotFoundException | ParseException e) {
+			throw new Exceptions.ParseException(e);
+		}
+	}
+
+
+	/* *********************
+	 *    Export Section
+	 ***********************/
+
+	@Override
+	public void writeEdif(String edifOutputFile, CellDesign design) {
+	}
+
+}
+	

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/yosys/YosysInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/yosys/YosysInterface.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2019 Brigham Young University
+ *
+ * This file is part of the BYU RapidSmith Tools.
+ *
+ * BYU RapidSmith Tools is free software: you may redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * BYU RapidSmith Tools is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GNU General Public License is included with the BYU
+ * RapidSmith Tools. It can be found at doc/LICENSE.GPL3.TXT. You may
+ * also get a copy of the license at <http://www.gnu.org/licenses/>.
+ */
+
+package edu.byu.ece.rapidSmith.interfaces.yosys;
+
+import edu.byu.ece.rapidSmith.RSEnvironment;
+import edu.byu.ece.rapidSmith.design.subsite.*;
+import edu.byu.ece.rapidSmith.device.Device;
+import edu.byu.ece.rapidSmith.interfaces.vivado.*;
+import edu.byu.ece.rapidSmith.util.Exceptions;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * This class is used to interface Yosys and RapidSmith2.
+ * It parses RSCP checkpoints containing Yosys-produced EDIFs and creates equivalent RapidSmith {@link CellDesign}s.
+ */
+public final class YosysInterface {
+	private static final String CELL_LIBRARY_NAME = "cellLibrary.xml";
+
+
+	public static VivadoCheckpoint loadRSCP(String rscp) throws IOException {
+		return loadRSCP(rscp, false);
+	}
+
+	/**
+	 * Parses a RSCP containing a Yosys EDIF, and creates an equivalent RapidSmith2 design.
+	 * @param rscp Path to the RSCP to import. Expected to contain a YOSYS-produced EDIF and a macros.xml file.
+	 * @param transformCells Whether or not to transform cells. Only transforms MUXCY, XORCY cells to CARRY4 cells right now.
+	 * @throws IOException
+	 */
+	public static VivadoCheckpoint loadRSCP(String rscp, boolean transformCells) throws IOException {
+		Path rscpPath = Paths.get(rscp);
+		
+		if (!rscpPath.getFileName().toString().endsWith(".rscp")) {
+			throw new AssertionError("Specified directory is not a RSCP. The directory should end in \".rscp\"");
+		}
+					
+		// load the device
+		DesignInfoInterface designInfo = new DesignInfoInterface();
+		designInfo.parse(rscpPath);
+		String partName = designInfo.getPart();
+		ImplementationMode mode = designInfo.getMode();
+		if (partName == null) {
+			throw new Exceptions.ParseException("Part name for the design not found in the design.info file!");
+		}
+		
+		Device device = RSEnvironment.defaultEnv().getDevice(partName);
+		
+		if (device == null) {
+			throw new Exceptions.EnvironmentException("Device files for part: " + partName + " cannot be found.");
+		}
+
+		// load the cell library
+		CellLibrary libCells = new CellLibrary(RSEnvironment.defaultEnv()
+				.getPartFolderPath(partName)
+				.resolve(CELL_LIBRARY_NAME));
+		
+		// add additional macro cell specifications to the cell library before parsing the EDIF netlist
+		libCells.loadMacroXML(rscpPath.resolve("macros.xml"));
+		
+		// create the RS2 netlist
+		String edifFile = rscpPath.resolve("netlist.edf").toString();
+
+		CellDesign design;
+		YosysEdifInterface yosysEdifInterface = new YosysEdifInterface();
+		design = yosysEdifInterface.parseEdif(edifFile, libCells, partName, transformCells);
+		design.setImplementationMode(mode);
+		
+		// parse the constraints into RapidSmith2
+		String constraintsFile = rscpPath.resolve("constraints.xdc").toString();
+		XdcConstraintsInterface constraintsInterface = new XdcConstraintsInterface(design, device);
+		constraintsInterface.parseConstraintsXDC(constraintsFile);
+
+		return new VivadoCheckpoint(partName, design, device, libCells);
+	}
+
+}

--- a/src/test/java/design/rscpImport/EdifTests.java
+++ b/src/test/java/design/rscpImport/EdifTests.java
@@ -22,21 +22,20 @@ package design.rscpImport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import edu.byu.ece.rapidSmith.interfaces.vivado.EdifInterface;
+import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoEdifInterface;
 import edu.byu.ece.rapidSmith.util.Exceptions;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
-
 /**
- * This class is used to test the {@link EdifInterface}. Add tests as necessary.
+ * This class is used to test the {@link VivadoEdifInterface}. Add tests as necessary.
  */
 public class EdifTests {
 
 	@Test
 	@DisplayName("Parse Exception")
-	public void exceptionTest() throws IOException {
-		assertThrows(Exceptions.ParseException.class, () -> EdifInterface.parseEdif("bogusEdifFile.edf", null));
+	public void exceptionTest() {
+		VivadoEdifInterface vivadoEdifInterface = new VivadoEdifInterface();
+		assertThrows(Exceptions.ParseException.class, () -> vivadoEdifInterface.parseEdif("bogusEdifFile.edf", null, null));
 	}
 }

--- a/src/test/java/design/rscpImport/ImportTests.java
+++ b/src/test/java/design/rscpImport/ImportTests.java
@@ -34,6 +34,7 @@ public class ImportTests {
 	@BeforeAll
 	public static void initializeClass() {
 		EdifInterface.suppressWarnings(true);
+		EdifInterface.suppressInfoMessages(true);
 	}
 	
 	@Test

--- a/src/test/java/design/rscpImport/ImportTests.java
+++ b/src/test/java/design/rscpImport/ImportTests.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import edu.byu.ece.rapidSmith.RSEnvironment;
 import edu.byu.ece.rapidSmith.design.subsite.Cell;
 import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
-import edu.byu.ece.rapidSmith.interfaces.vivado.EdifInterface;
+import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoEdifInterface;
 import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoCheckpoint;
 import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoInterface;
 
@@ -33,8 +33,8 @@ public class ImportTests {
 	 */
 	@BeforeAll
 	public static void initializeClass() {
-		EdifInterface.suppressWarnings(true);
-		EdifInterface.suppressInfoMessages(true);
+		VivadoEdifInterface.suppressWarnings(true);
+		VivadoEdifInterface.suppressInfoMessages(true);
 	}
 	
 	@Test

--- a/src/test/java/design/tcpExport/EdifCellPropertyTest.java
+++ b/src/test/java/design/tcpExport/EdifCellPropertyTest.java
@@ -10,7 +10,7 @@ import edu.byu.ece.rapidSmith.design.subsite.Cell;
 import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
 import edu.byu.ece.rapidSmith.design.subsite.Property;
 import edu.byu.ece.rapidSmith.design.subsite.PropertyType;
-import edu.byu.ece.rapidSmith.interfaces.vivado.EdifInterface;
+import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoEdifInterface;
 import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoCheckpoint;
 import edu.byu.ece.rapidSmith.interfaces.vivado.VivadoInterface;
 import org.junit.jupiter.api.AfterAll;
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-/**tests the {@link EdifInterface} to verify that edif Property lists only contain EDIF type properties
+/**tests the {@link VivadoEdifInterface} to verify that edif Property lists only contain EDIF type properties
   *Only EDIF Property Types are allowed in the netlist.edf to be imported into Vivado using Tincr.
   * @author Dallon Glick
   * @author Jesse Grigg
@@ -74,7 +74,8 @@ public class EdifCellPropertyTest {
         Cell cell = design.getCell("q[8]_i_2");
         Property designProp = new Property("DesignPropKey", PropertyType.DESIGN, "DesignPropVal");
         cell.getProperties().add(designProp);
-        EdifInterface.writeEdif(testEdifPath.toString(), design);
+        VivadoEdifInterface vivadoEdifInterface = new VivadoEdifInterface();
+        vivadoEdifInterface.writeEdif(testEdifPath.toString(), design);
 
         try {
             EdifEnvironment env = EdifParser.translate(testEdifPath.toString());
@@ -97,7 +98,8 @@ public class EdifCellPropertyTest {
         Cell cell = design.getCell("q[8]_i_2");
         Property userProp = new Property("userPropKey", PropertyType.USER, "userPropVal");
         cell.getProperties().add(userProp);
-        EdifInterface.writeEdif(testEdifPath.toString(), design);
+        VivadoEdifInterface vivadoEdifInterface = new VivadoEdifInterface();
+        vivadoEdifInterface.writeEdif(testEdifPath.toString(), design);
 
         try {
             EdifEnvironment env = EdifParser.translate(testEdifPath.toString());
@@ -118,7 +120,8 @@ public class EdifCellPropertyTest {
         Cell cell2 = design.getCell("q[8]_i_2");
         Property belProp = new Property("belPropKey", PropertyType.BELPROP, "belPropVal");
         cell2.getProperties().add(belProp);
-        EdifInterface.writeEdif(testEdifPath.toString(), design);
+        VivadoEdifInterface vivadoEdifInterface = new VivadoEdifInterface();
+        vivadoEdifInterface.writeEdif(testEdifPath.toString(), design);
         try {
             EdifEnvironment env = EdifParser.translate(testEdifPath.toString());
             EdifCell topLevelCell = env.getTopCell();
@@ -140,7 +143,8 @@ public class EdifCellPropertyTest {
         Cell cell2 = design.getCell("q[8]_i_2");
         Property edifProp = new Property("edifPropKey", PropertyType.EDIF, "edifPropVal");
         cell2.getProperties().add(edifProp);
-        EdifInterface.writeEdif(testEdifPath.toString(), design);
+        VivadoEdifInterface vivadoEdifInterface = new VivadoEdifInterface();
+        vivadoEdifInterface.writeEdif(testEdifPath.toString(), design);
 
         try {
             EdifEnvironment env = EdifParser.translate(testEdifPath.toString());


### PR DESCRIPTION
Adds a Yosys Interface, Yosys Edif Interface, and an Abstract Edif Interface. Also changed Edif Interface to Vivado Edif Interface.

The Vivado and Yosys Edif Interfaces share many methods (hence the abstract edif interface), but there are some differences between the EDIF files produced by Vivado and Yosys.

The main difference handled by the Yosys Edif Interface is that Yosys will produce EDIFs with MUXCY and XORCY cells, whereas Vivado normally will not. If the "transformCells" boolean is set to true when importing an RSCP containing a Yosys EDIF (and if the device's cell library has CARRY4 cells), the MUXCY and XORCY cells will be transformed into equivalent CARRY4 cells. This is similar to what Vivado does when a netlist with MUXCY and XORCY cells is read in used read_edif; after linking the design, you will see a message such as: 
```
INFO: [Project 1-111] Unisim Transformation Summary:
  A total of 11 instances were transformed.
  (MUXCY,XORCY) => CARRY4: 11 instances
```

It is helpful to transform these cells for use with some CAD tools, such as RSVPack. Right now, only transforming XORCY and MUXCY cells to CARRY4 cells is supported, but this could probably be extended to CARRY8 cells without too much issue in the future. 

I've tested the Yosys Interface (and the CARRY4 transformation code) with a small set of Yosys EDIFs at this point.