### PR TITLE
Separate staticSourceBels into vccSourceBels and gndSourceBels

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoCheckpoint.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoCheckpoint.java
@@ -21,6 +21,7 @@
 package edu.byu.ece.rapidSmith.interfaces.vivado;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,7 +44,8 @@ public final class VivadoCheckpoint {
 	private final String partName;
 	private Set<Bel> routethroughBels;
 	private Collection<BelRoutethrough> routethroughObjects;
-	private Collection<Bel> staticSourceBels;
+	private Collection<Bel> vccSourceBels;
+	private Collection<Bel> gndSourceBels;
 	private Map<BelPin, CellPin> belPinToCellPinMap;
 
 	public VivadoCheckpoint(String partName, CellDesign design, Device device, CellLibrary libCells) {
@@ -95,13 +97,28 @@ public final class VivadoCheckpoint {
 	public Set<Bel> getBelRoutethroughs() {
 		return routethroughBels;
 	}
-	
-	public void setStaticSourceBels(Collection<Bel> bels) {
-		this.staticSourceBels = bels;
-	}
-	
+
 	public Collection<Bel> getStaticSourceBels() {
-		return this.staticSourceBels;
+		Collection<Bel> staticSourceBels = new HashSet<>();
+		staticSourceBels.addAll(vccSourceBels);
+		staticSourceBels.addAll(gndSourceBels);
+		return staticSourceBels;
+	}
+
+	public Collection<Bel> getVccSourceBels() {
+		return vccSourceBels;
+	}
+
+	public void setVccSourceBels(Collection<Bel> vccSourceBels) {
+		this.vccSourceBels = vccSourceBels;
+	}
+
+	public Collection<Bel> getGndSourceBels() {
+		return gndSourceBels;
+	}
+
+	public void setGndSourceBels(Collection<Bel> gndSourceBels) {
+		this.gndSourceBels = gndSourceBels;
 	}
 	
 	public void setBelPinToCellPinMap(Map<BelPin, CellPin> pinMap) {

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
@@ -106,7 +106,8 @@ public final class VivadoInterface {
 		
 		if (storeAdditionalInfo) {
 			vivadoCheckpoint.setRoutethroughBels(routingInterface.getRoutethroughsBels());
-			vivadoCheckpoint.setStaticSourceBels(routingInterface.getStaticSourceBels());
+			vivadoCheckpoint.setVccSourceBels(routingInterface.getVccSourceBels());
+			vivadoCheckpoint.setGndSourceBels(routingInterface.getGndSourceBels());
 			vivadoCheckpoint.setBelPinToCellPinMap(placementInterface.getPinMap());
 		}
 		


### PR DESCRIPTION
All static source bels were added into one collection upon RSCP import. For some cases (like exporting a FASM) it is more helpful to have separate collections for vcc and gnd bel sources. This PR separates them, but retains a getStaticSourceBels method.

I also cleaned up some unused methods, etc. in XdcRoutingInterface.