### PR TITLE
Partition Pin Class

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/BackedCellPin.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/BackedCellPin.java
@@ -24,10 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import edu.byu.ece.rapidSmith.device.Bel;
-import edu.byu.ece.rapidSmith.device.BelId;
-import edu.byu.ece.rapidSmith.device.BelPin;
-import edu.byu.ece.rapidSmith.device.PinDirection;
+import edu.byu.ece.rapidSmith.device.*;
 
 /**
  *  A CellPin that is "backed" by a {@link LibraryPin}. This means they represent 
@@ -82,6 +79,11 @@ public class BackedCellPin extends CellPin {
 	}
 
 	@Override
+	public boolean isPartitionPin() {
+		return false;
+	}
+
+	@Override
 	public List<BelPin> getPossibleBelPins() {
 		return getPossibleBelPins(getCell().getBel());
 	}
@@ -122,5 +124,10 @@ public class BackedCellPin extends CellPin {
 	@Override
 	public CellPin getExternalPin() {		
 		return isInternal() ? getCell().getParent().getExternalPin(this) : null;
+	}
+
+	@Override
+	public Wire getPartPinWire() {
+		return null;
 	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
@@ -309,10 +309,8 @@ public class CellNet implements Serializable {
 			pin.getCell().mapToInternalPins(pin).forEach(this::connectToLeafPin);
 			pin.setNet(this);
 		}
-		// If the cellpin drives a static net, but the cell is not a VCC or GND cell, do not
-		// attempt to disconnect. This can come up with static source LUTs, etc.
-		else if (!(pin.getNet().isStaticNet() && pin.isOutpin() && !pin.getCell().isStaticSource())) {
-			disconnectFromLeafPin(pin);
+		else {
+			connectToLeafPin(pin);
 		}
 	}
 	
@@ -407,7 +405,9 @@ public class CellNet implements Serializable {
 			pin.getCell().mapToInternalPins(pin).forEach(this::disconnectFromLeafPin);
 			pin.clearNet();
 		}
-		else {
+		// If the cellpin drives a static net, but the cell is not a VCC or GND cell, do not
+		// attempt to disconnect. This can come up with static source LUTs, etc.
+		else if (!(pin.getNet().isStaticNet() && pin.isOutpin() && !pin.getCell().isStaticSource())) {
 			disconnectFromLeafPin(pin);
 		}
 	}

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellNet.java
@@ -202,6 +202,47 @@ public class CellNet implements Serializable {
 	}
 
 	/**
+	 * Returns the pseudo pins of the net. This structure should not be modified by the user.
+	 *
+	 * @return pseudo pins of this net
+	 */
+	public Collection<CellPin> getPseudoPins() {
+		return getPins().stream()
+				.filter(CellPin::isPseudoPin)
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns the partition pins of the net. This structure should not be modified by the user.
+	 *
+	 * @return Partition pins of the net
+	 */
+	public Collection<CellPin> getPartitionPins() {
+		return getPins().stream()
+				.filter(CellPin::isPartitionPin)
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns the partition pins of the net that act as sinks. This structure should not be modified by the user.
+	 * @return Sink partition pins of the net.
+	 */
+	public Collection<CellPin> getSinkPartitionPins() {
+		return getPins().stream()
+				.filter(CellPin::isPartitionPin)
+				.filter(p -> p != sourcePin)
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns whether or not the net has at least one associated partition pin.
+	 * @return
+	 */
+	public boolean hasPartitionPin() {
+		return getPins().stream().anyMatch(CellPin::isPartitionPin);
+	}
+
+	/**
 	 * Checks if this net has a source pin.
 	 *
 	 * @return true if this net has a source pin
@@ -226,7 +267,7 @@ public class CellNet implements Serializable {
 	 * @return all of the pins that source the net
 	 */
 	public List<CellPin> getAllSourcePins() {
-		return sourcePins.stream().collect(Collectors.toList());
+		return new ArrayList<>(sourcePins);
 	}
 
 	/**
@@ -262,15 +303,16 @@ public class CellNet implements Serializable {
 	 * @param pin the new {@link CellPin} to add
 	 */
 	public void connectToPin(CellPin pin) {
-		
 		// If the cellpin is part of a macro cell, add all of the internal pins
 		// to the net instead of the external macro pins
-		if (pin.getCell().isMacro()) {
+		if (!pin.isPartitionPin() && pin.getCell().isMacro()) {
 			pin.getCell().mapToInternalPins(pin).forEach(this::connectToLeafPin);
 			pin.setNet(this);
 		}
-		else {
-			connectToLeafPin(pin);
+		// If the cellpin drives a static net, but the cell is not a VCC or GND cell, do not
+		// attempt to disconnect. This can come up with static source LUTs, etc.
+		else if (!(pin.getNet().isStaticNet() && pin.isOutpin() && !pin.getCell().isStaticSource())) {
+			disconnectFromLeafPin(pin);
 		}
 	}
 	
@@ -303,7 +345,6 @@ public class CellNet implements Serializable {
 	 * This operation has a complexity of O(n).
 	 */
 	public int getPseudoPinCount() {
-		
 		int pseudoPinCount = 0;
 		
 		for (CellPin pin : pins) {
@@ -417,12 +458,35 @@ public class CellNet implements Serializable {
 	 * @return {@code true} if this net is a clock net
 	 */
 	public boolean isClkNet() {
+		// Don't consider static nets as clock nets even if they have clock pins
+		if (isStaticNet())
+			return false;
+
 		for (CellPin p : this.pins) {
-			if (p.getType() == CellPinType.CLOCK) {
+			if (p.getType() == CellPinType.CLOCK || p.getType() == CellPinType.PARTITION_CLK) {
 				return true;
 			}
 		}
 		
+		return false;
+	}
+
+	/**
+	 * Checks if a net is a partition pin clock net (but not a true clock net).
+	 * Checks that the net is not a true clock net and checks if any attached partition
+	 * pins are of type {@link CellPinType#PARTITION_CLK}.
+	 *
+	 * @return {@code true} if this net is a partition pin clock net
+	 */
+	public boolean isPartPinCLKNet() {
+		for (CellPin p : this.pins) {
+			if (p.getType() == CellPinType.CLOCK) {
+				return false;
+			}
+			else if (p.getType() == CellPinType.PARTITION_CLK) {
+				return true;
+			}
+		}
 		return false;
 	}
 	
@@ -523,11 +587,11 @@ public class CellNet implements Serializable {
 	 * 		If the site pin was not a source pin for the net, {@code false} will be returned.
 	 */
 	public boolean removeSourceSitePin(SitePin sitePin) {
-		return this.sourceSitePinList == null ? false : this.sourceSitePinList.remove(sitePin); 
+		return this.sourceSitePinList != null && this.sourceSitePinList.remove(sitePin);
 	}
 	
 	/**
-	 * Removes all source site pins from the net. 
+	 * Removes all source site pins from the net.
 	 */
 	public void removeAllSourceSitePins(){
 		this.sourceSitePinList = null;

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPin.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPin.java
@@ -27,11 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import edu.byu.ece.rapidSmith.device.Bel;
-import edu.byu.ece.rapidSmith.device.BelId;
-import edu.byu.ece.rapidSmith.device.BelPin;
-import edu.byu.ece.rapidSmith.device.PinDirection;
-import edu.byu.ece.rapidSmith.device.SitePin;
+import edu.byu.ece.rapidSmith.device.*;
 import edu.byu.ece.rapidSmith.util.Exceptions;
 
 /**
@@ -271,6 +267,7 @@ public abstract class CellPin implements Serializable {
 			return null;
 		}
 		else {
+			assert (belPinMappingSet.size() == 1);
 			return belPinMappingSet.iterator().next();
 		}
 	}
@@ -300,7 +297,7 @@ public abstract class CellPin implements Serializable {
 	 * @param belPin BelPin to un-map
 	 */
 	public void clearPinMapping(BelPin belPin) {
-		if (belPinMappingSet != null && belPinMappingSet.contains(belPin)) {
+		if (belPinMappingSet != null) {
 			belPinMappingSet.remove(belPin);
 		}
 	}
@@ -336,7 +333,12 @@ public abstract class CellPin implements Serializable {
 	/** 
 	 * @return <code>true</code> if the pin is a pseudo pin. <code>false</code> otherwise.
 	 */
-	public abstract boolean isPseudoPin(); 
+	public abstract boolean isPseudoPin();
+
+	/**
+	 * @return <code>true</code> if the pin is a partition pin. <code>false</code> otherwise.
+	 */
+	public abstract boolean isPartitionPin();
 	
 	/**
 	 * Returns the BelPins that this pin can potentially be mapped onto. The BEL that this pin's parent
@@ -393,12 +395,21 @@ public abstract class CellPin implements Serializable {
 	public abstract CellPinType getType();
 	
 	/**
-	 * If the 
-	 * @return 
+	 * @return the external pin
 	 */
 	public abstract CellPin getExternalPin();
 
-	public void setMacroPinToGlobalNet(CellNet n) {
+	/**
+	 * @return the partition pin wire (if the pin is a partition pin)
+	 */
+	public abstract Wire getPartPinWire();
+
+	/**
+	 * Manually set a pin to a global net. Not for normal use. Should only be used for macro pins, partition pins, or
+	 * static-source LUTs.
+	 * @param n the global net to set the pin to
+	 */
+	public void setPinToGlobalNet(CellNet n) {
 		setNet(n);
 	}
 

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPinType.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellPinType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Brigham Young University
+ * Copyright (c) 2019 Brigham Young University
  *
  * This file is part of the BYU RapidSmith Tools.
  *
@@ -23,11 +23,11 @@ package edu.byu.ece.rapidSmith.design.subsite;
 /**
  * Each cell pin in Vivado has an associated type. {@code CellPinType)
  * represents the possible cell pin types available in Vivado. This is useful, for example,
- * to determine if a pin is a clock pin. When changing versions of Vivado, 
+ * to determine if a pin is a clock pin. When changing versions of Vivado,
  * run the command {@code report_property -class pin} in an open Vivado TCL
  * command prompt, and look at the IS_* properties. NOTE: not all of these properties 
  * will correspond to a pin type.  
- * 
+ *
  * @author Thomas Townsend
  *
  */
@@ -41,7 +41,9 @@ public enum CellPinType {
 	SET,
 	SETRESET,
 	WRITE_ENABLE,
-	DATA, 
+	DATA,
 	PSEUDO,
-	MACRO
+	MACRO,
+	PARTITION,
+	PARTITION_CLK
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/PartitionPin.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/PartitionPin.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2019 Brigham Young University
+ *
+ * This file is part of the BYU RapidSmith Tools.
+ *
+ * BYU RapidSmith Tools is free software: you may redistribute it
+ * and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * BYU RapidSmith Tools is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GNU General Public License is included with the BYU
+ * RapidSmith Tools. It can be found at doc/LICENSE.GPL3.TXT. You may
+ * also get a copy of the license at <http://www.gnu.org/licenses/>.
+ */
+
+package edu.byu.ece.rapidSmith.design.subsite;
+
+import edu.byu.ece.rapidSmith.device.*;
+
+import java.util.List;
+
+/**
+ * This class represents a Partition Pin.
+ *
+ * @author Dallon Glick
+ */
+public class PartitionPin extends CellPin {
+
+    /**
+     * Unique Serial Version for this class
+     */
+    private static final long serialVersionUID = -4765068478025538798L;
+    /**
+     * Name of the pseudo pin
+     */
+    private final String name;
+    /**
+     * Direction of the pseudo pin relative to the cell
+     */
+    private final PinDirection direction;
+    /**
+     * {@link CellPinType} of the pin
+     */
+    private final CellPinType pinType;
+    /**
+     * The partition pin's corresponding wire
+     **/
+    private final Wire wire;
+
+    /**
+     * PartitionPin Constructor. Creates a partition pin that does not
+     * have a parent cell.
+     *
+     * @param portCell the OOC port
+     * @param pinDir   Direction of the pin relative to cell it's attached to
+     */
+    public PartitionPin(Cell portCell, Wire wire, PinDirection pinDir) {
+        super(portCell);
+        this.name = portCell.getName();
+        this.direction = pinDir;
+        this.wire = wire;
+
+        // If the partition pin wire is an HCLK row, it is a special clock partition pin
+        // Is there a better way to identify this other than the name of the wire?
+        this.pinType = (wire != null && wire.getName().contains("CLK_HROW")) ? CellPinType.PARTITION_CLK : CellPinType.PARTITION;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getFullName() {
+        return name;
+    }
+
+    @Override
+    public PinDirection getDirection() {
+        return direction;
+    }
+
+    @Override
+    public boolean isPseudoPin() {
+        return false;
+    }
+
+    @Override
+    public boolean isPartitionPin() {
+        return true;
+    }
+
+    @Override
+    public Wire getPartPinWire() {
+        return wire;
+    }
+
+    @Override
+    public List<BelPin> getPossibleBelPins() {
+        return null;
+    }
+
+    @Override
+    public List<BelPin> getPossibleBelPins(Bel bel) {
+        return null;
+    }
+
+    @Override
+    public List<String> getPossibleBelPinNames() {
+        return null;
+    }
+
+    @Override
+    public List<String> getPossibleBelPinNames(BelId belId) {
+        return null;
+    }
+
+    @Override
+    public LibraryPin getLibraryPin() {
+        return null;
+    }
+
+    @Override
+    public CellPinType getType() {
+        return pinType;
+    }
+
+    @Override
+    public CellPin getExternalPin() {
+        return null;
+    }
+
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/PseudoCellPin.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/PseudoCellPin.java
@@ -22,10 +22,7 @@ package edu.byu.ece.rapidSmith.design.subsite;
 
 import java.util.List;
 
-import edu.byu.ece.rapidSmith.device.Bel;
-import edu.byu.ece.rapidSmith.device.BelId;
-import edu.byu.ece.rapidSmith.device.BelPin;
-import edu.byu.ece.rapidSmith.device.PinDirection;
+import edu.byu.ece.rapidSmith.device.*;
 
 /**
  * This class represents a PseudoCellPin: a pin that can be created dynamically
@@ -125,4 +122,13 @@ public class PseudoCellPin extends CellPin {
 		return null;
 	}
 
+	@Override
+	public boolean isPartitionPin() {
+		return false;
+	}
+
+	@Override
+	public Wire getPartPinWire() {
+		return null;
+	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/AbstractEdifInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/AbstractEdifInterface.java
@@ -399,9 +399,9 @@ public abstract class AbstractEdifInterface {
 			for (CellPin cp : c.getPins()) {
 				if (cp.getNet()!= null) {
 					if (cp.getNet() != globalGNDNet && cp.getNet().getType() == NetType.GND)
-						cp.setMacroPinToGlobalNet(globalGNDNet);
+						cp.setPinToGlobalNet(globalGNDNet);
 					else if (cp.getNet() != globalVCCNet && cp.getNet().getType() == NetType.VCC)
-						cp.setMacroPinToGlobalNet(globalVCCNet);
+						cp.setPinToGlobalNet(globalVCCNet);
 				}
 			}
 		}


### PR DESCRIPTION
Adds a partition pin class that extends the CellPin class. This PR does not include import/export functionality for partition pins. That will come in a later pull request.