### PR TITLE
Methods to get wires in a node + extra XDCConstraint constructor

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/device/SiteWire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/SiteWire.java
@@ -24,10 +24,7 @@ import edu.byu.ece.rapidSmith.device.Connection.ReverseSiteWireConnection;
 import edu.byu.ece.rapidSmith.device.Connection.SiteWireConnection;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singleton;
@@ -112,6 +109,17 @@ public class SiteWire implements Wire, Serializable {
 	
 	public WireConnection[] getWireConnectionsArray() {
 		return site.getWireConnections(siteType, wire);
+	}
+
+	/**
+	 * Gets wires that make up a node. This is just the single wire for site wires.
+	 * @return a set containing the wire
+	 */
+	@Override
+	public Set<Wire> getWiresInNode() {
+		Set<Wire> wires = new HashSet<>();
+		wires.add(this);
+		return wires;
 	}
 
 	@Override

--- a/src/main/java/edu/byu/ece/rapidSmith/device/TileWire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/TileWire.java
@@ -24,10 +24,7 @@ import edu.byu.ece.rapidSmith.device.Connection.ReverseTileWireConnection;
 import edu.byu.ece.rapidSmith.device.Connection.TileWireConnection;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -110,6 +107,30 @@ public class TileWire implements Wire, Serializable {
 	
 	public WireConnection[] getWireConnectionsArray(){
 		return tile.getWireConnections(wire);
+	}
+
+	/**
+	 * Gets wires that are part of the same node.
+	 * Only includes start and end wires (intermediate wires aren't included)
+	 * @return a set including the wires of the node
+	 */
+	@Override
+	public Set<Wire> getWiresInNode() {
+		Set<Wire> wiresInNode = new HashSet<>();
+		wiresInNode.add(this);
+		Collection<Connection> directForwardConnections = getWireConnections().stream()
+				.filter(connection -> !connection.isPip()).collect(Collectors.toList());
+		Collection<Connection> directReverseConnections = getReverseWireConnections().stream()
+				.filter(connection -> !connection.isPip()).collect(Collectors.toList());
+
+		for (Connection conn : directForwardConnections) {
+			wiresInNode.add(conn.getSinkWire());
+		}
+		for (Connection conn : directReverseConnections) {
+			wiresInNode.add(conn.getSinkWire());
+		}
+
+		return wiresInNode;
 	}
 
 	@Override

--- a/src/main/java/edu/byu/ece/rapidSmith/device/Wire.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/Wire.java
@@ -22,6 +22,7 @@ package edu.byu.ece.rapidSmith.device;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * Wires represent a piece of metal on a device.  Wires are composed of two
@@ -96,4 +97,10 @@ public interface Wire extends Serializable {
 	 * Returns the sources (BelPins) which drive this wire.
 	 */
 	BelPin getSource();
+
+	/**
+	 * Returns all beginning and end wires that make up a node. Does not include intermediate wires.
+	 * @return beginning and end wires of a node.
+	 */
+	Set<Wire> getWiresInNode();
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcConstraint.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcConstraint.java
@@ -49,6 +49,10 @@ public final class XdcConstraint {
 			constraintPackagePin = new XdcConstraintPackagePin(matcher.group(1), matcher.group(2));
 		}
 	}
+
+	public XdcConstraint(String command, String options) {
+		this(command, options, null);
+	}
 	
 	/**
 	 * @return The name of the XDC constraint command


### PR DESCRIPTION
The main part of this PR adds getWiresInNodes methods. Note that this only gets the beginning and end wires of a node (Since RS2 omits the intermediate wires from the wire connections).