### PR TITLE
Various Router and Maverick Related Changes

### DIFF
--- a/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/design/subsite/CellDesign.java
@@ -112,6 +112,23 @@ public class CellDesign extends AbstractDesign {
 		mode = ImplementationMode.REGULAR;
 		pipInValues = new HashMap<>();
 		reservedWires = new HashMap<>();
+		reservedSites = new HashSet<>();
+	}
+
+	/**
+	 * Returns a flattened view of the in-context cells in the netlist. Macro
+	 * cells are not returned in this list, only leaf and internal cells
+	 * are returned.
+	 * WARNING: Ports are assumed to be out-of-context. This is true for 7-Series RMs, but is
+	 * not necessarily true for ultrascale RMs.
+	 */
+	public Stream<Cell> getInContextLeafCells() {
+		// TODO: For non 7-series designs, determine which ports are in-context and which are out-of-context
+		// TODO: Also check ImplementationMode.OUT_OF_CONTEXT
+		if (this.mode.equals(ImplementationMode.RECONFIG_MODULE))
+			return (cellMap.values().stream().flatMap(c -> _flatten(c))).filter(it -> !it.isPort());
+		else
+			return cellMap.values().stream().flatMap(c -> _flatten(c));
 	}
 
 	/**
@@ -420,15 +437,9 @@ public class CellDesign extends AbstractDesign {
 			throw new Exceptions.DesignAssemblyException("Net with name already exists in design.");
 
 		if (net.isVCCNet()) {
-			// if (vccNet != null) {
-			// 	throw new DesignAssemblyException("VCC net already exists in design.");
-			// }
 			vccNet = net;
 		}
 		else if (net.isGNDNet()) {
-			// if (gndNet != null) {
-			// 	throw new DesignAssemblyException("GND net already exists in design.");
-			// }
 			gndNet = net;
 		} 
 		
@@ -943,8 +954,6 @@ public class CellDesign extends AbstractDesign {
 	 * @param site site to reserve
 	 */
 	public void addReservedSite(Site site) {
-		if (reservedSites == null)
-			reservedSites = new HashSet<>();
 		reservedSites.add(site);
 	}
 
@@ -1061,5 +1070,5 @@ public class CellDesign extends AbstractDesign {
 	public void setStaticRouteStringMap(Map<String, RouteStringTree> staticRouteStringMap) {
 		this.staticRouteStringMap = staticRouteStringMap;
 	}
-	
+
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/device/creation/PartialDeviceGenerator.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/device/creation/PartialDeviceGenerator.java
@@ -85,10 +85,10 @@ public class PartialDeviceGenerator {
 		}
 
 		// Get the top left and bottom right tiles
-		int topLeftRow = (tileA.getRow() < tileB.getRow()) ? tileA.getRow() : tileB.getRow();
-		int topLeftCol = (tileA.getColumn() < tileB.getColumn()) ? tileA.getColumn() : tileB.getColumn();
-		int bottRightRow = (tileA.getRow() > tileB.getRow()) ? tileA.getRow() : tileB.getRow();
-		int bottRightCol = (tileA.getColumn() > tileB.getColumn()) ? tileA.getColumn() : tileB.getColumn();
+		int topLeftRow = Math.min(tileA.getRow(), tileB.getRow());
+		int topLeftCol = Math.min(tileA.getColumn(), tileB.getColumn());
+		int bottRightRow = Math.max(tileA.getRow(), tileB.getRow());
+		int bottRightCol = Math.max(tileA.getColumn(), tileB.getColumn());
 
 		Tile topLeft = oldDevice.getTile(topLeftRow, topLeftCol);
 		Tile bottomRight = oldDevice.getTile(bottRightRow, bottRightCol);

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/AbstractXdcInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/AbstractXdcInterface.java
@@ -6,6 +6,8 @@ import edu.byu.ece.rapidSmith.design.subsite.ImplementationMode;
 import edu.byu.ece.rapidSmith.device.*;
 import edu.byu.ece.rapidSmith.util.Exceptions;
 
+import java.util.regex.Pattern;
+
 public abstract class AbstractXdcInterface {
 
     protected final Device device;
@@ -14,6 +16,7 @@ public abstract class AbstractXdcInterface {
     protected int currentLineNumber;
     protected String currentFile;
     protected ImplementationMode implementationMode;
+    protected Pattern pipNamePattern;
 
     public AbstractXdcInterface(Device device, CellDesign design) {
         this.device = device;
@@ -21,6 +24,25 @@ public abstract class AbstractXdcInterface {
         this.wireEnumerator = device.getWireEnumerator();
         this.currentLineNumber = 0;
         this.implementationMode = design.getImplementationMode();
+        this.pipNamePattern = Pattern.compile("(.*)/.*\\.([^<]*)((?:<<)?->>?)(.*)");
+    }
+
+    /**
+     * Tries to retrieve a BelPin object from the currently loaded device <br>
+     * If the pin does not exist, a ParseException is thrown. <br>
+     *
+     * @param bel Bel which the pin is attached
+     * @param pinName Name of the bel pin
+     * @return BelPin
+     */
+    protected BelPin tryGetBelPin(Bel bel, String pinName) {
+        BelPin pin = bel.getBelPin(pinName);
+
+        if (pin == null) {
+            throw new Exceptions.ParseException(String.format("BelPin: \"%s/%s\" does not exist in the current device"
+                    + "On line %d of %s", bel.getName(), pinName, currentLineNumber, currentFile));
+        }
+        return pin;
     }
 
     /**

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/PseudoCellHandler.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/PseudoCellHandler.java
@@ -1,0 +1,206 @@
+package edu.byu.ece.rapidSmith.interfaces.vivado;
+
+import edu.byu.ece.rapidSmith.design.subsite.*;
+import edu.byu.ece.rapidSmith.device.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class PseudoCellHandler {
+	private final CellDesign design;
+	private final Device device;
+	private final CellLibrary libCells;
+
+	public PseudoCellHandler(CellDesign design, Device device, CellLibrary libCells) {
+		this.design = design;
+		this.device = device;
+		this.libCells = libCells;
+	}
+
+
+	/**
+	 * Creates a route tree, starting from an input site pin and ending at a BelPin.
+	 * Used for pseudo VCC pins.
+	 * @param net the vcc net
+	 * @param sinkPin
+	 */
+	private void createPseudoVccSinkTree(CellNet net, BelPin sinkPin) {
+		// The BelPin must be a sink Lut BEL Pin
+		Wire lutPinWire = sinkPin.getWire().getReverseWireConnections().iterator().next().getSinkWire();
+		SitePin sitePin = lutPinWire.getReverseConnectedPin();
+		RouteTree rt = new RouteTree(sitePin.getInternalWire());
+		rt.connect(lutPinWire.getWireConnections().iterator().next());
+		net.addSinkRouteTree(sitePin, rt);
+		net.addSinkRouteTree(sinkPin, rt);
+	}
+
+	/**
+	 * Removes pseudo lut cells from the design. Pseudo cells are only used when pseudo pins are needed for
+	 * physical routing.
+	 * @param design the design
+	 */
+	void removePseudoLuts() {
+		for (Cell staticSource : design.getCells().stream()
+				.filter(Cell::isPseudo)
+				.collect(Collectors.toList())) {
+			design.removeCell(staticSource);
+		}
+	}
+
+	/**
+	 * Searches the design and adds pseudo cell pins for physical-only vcc routes that need to be made.
+	 */
+	void addPseudoVccPins() {
+		//CellDesign design = vivadoCheckpoint.getDesign();
+		CellNet vccNet = design.getVccNet();
+
+		// If a 5LUT Bel and a 6LUT Bel are both used, we must tie A6 to VCC
+		// Get ALL used LUT bels (including bels with no logical counterpart)
+		Collection<Bel> usedLut6Bels = design.getUsedBels().stream()
+				.filter(bel -> bel.getName().matches("[A-D]6LUT")).collect(Collectors.toList());
+		Collection<Bel> usedLut5Bels = design.getUsedBels().stream()
+				.filter(bel -> bel.getName().matches("[A-D]5LUT")).collect(Collectors.toList());
+
+		for (Bel bel : usedLut6Bels) {
+			Cell cell = design.getCellAtBel(bel);
+			assert (cell != null);
+
+			switch (cell.getType()) {
+				case "SRLC32E":
+					CellPin pin = cell.attachPseudoPin("pseudoA1", PinDirection.IN);
+					BelPin belPin = bel.getBelPin("A1");
+					pin.mapToBelPin(belPin);
+					vccNet.connectToPin(pin);
+					createPseudoVccSinkTree(vccNet, belPin);
+					break;
+				case "SRLC16E":
+				case "SRL16E":
+					CellPin a1pin = cell.attachPseudoPin("pseudoA1", PinDirection.IN);
+					belPin = bel.getBelPin("A1");
+					a1pin.mapToBelPin(belPin);
+					vccNet.connectToPin(a1pin);
+					createPseudoVccSinkTree(vccNet, belPin);
+
+					CellPin a6pin = cell.attachPseudoPin("pseudoA6", PinDirection.IN);
+					belPin = bel.getBelPin("A6");
+					a6pin.mapToBelPin(belPin);
+					vccNet.connectToPin(a6pin);
+					createPseudoVccSinkTree(vccNet, belPin);
+					break;
+				case "RAMS32":
+				case "RAMD32":
+					CellPin wa6pin = cell.attachPseudoPin("pseudoWA6", PinDirection.IN);
+					belPin = bel.getBelPin("WA6");
+					wa6pin.mapToBelPin(belPin);
+					vccNet.connectToPin(wa6pin);
+					createPseudoVccSinkTree(vccNet, belPin);
+
+					a6pin = cell.attachPseudoPin("pseudoA6", PinDirection.IN);
+					belPin = bel.getBelPin("A6");
+					a6pin.mapToBelPin(belPin);
+					vccNet.connectToPin(a6pin);
+					createPseudoVccSinkTree(vccNet, belPin);
+					break;
+				default:
+					break;
+			}
+		}
+
+		for (Bel bel : usedLut5Bels) {
+			Cell cell = design.getCellAtBel(bel);
+			assert (cell != null);
+
+			// Check to see if both the LUT6 and LUT5 BEL are used
+			Bel lut6Bel = bel.getSite().getBel(bel.getName().charAt(0) + "6LUT");
+			Cell lut6Cell = design.getCellAtBel(lut6Bel);
+			if (usedLut6Bels.contains(lut6Bel)) {
+				BelPin belPin = lut6Bel.getBelPin("A6");
+
+				boolean macroPseudoPin = false;
+				// Pseudo pins may have already been created for macro cells
+				// TODO: Get rid of this duplication of efforts.
+				for (CellPin pseudoPin : lut6Cell.getPseudoPins()) {
+					if (pseudoPin.getMappedBelPin().equals(belPin))
+						macroPseudoPin = true;
+				}
+
+				if (!macroPseudoPin) {
+					CellPin pin = lut6Cell.attachPseudoPin("pseudoA6", PinDirection.IN);
+
+					// Assume that vcc can be routed to this pin.
+					pin.mapToBelPin(belPin);
+					vccNet.connectToPin(pin);
+					createPseudoVccSinkTree(vccNet, belPin);
+				}
+			}
+
+			if (cell.getType().equals("SRLC16E") || cell.getType().equals("SRL16E")) {
+				CellPin pin = cell.attachPseudoPin("pseudoA1", PinDirection.IN);
+				BelPin belPin = bel.getBelPin("A1");
+				pin.mapToBelPin(belPin);
+				vccNet.connectToPin(pin);
+				createPseudoVccSinkTree(vccNet, belPin);
+			}
+
+		}
+
+		// We have added pins, so we need to recalculate the route status
+		vccNet.computeRouteStatus();
+	}
+
+	/**
+	 * Adds pseudo cells to the design for route-through LUTs, implied latches, and static source LUTs.
+	 */
+	void addPseudoCells(Set<Bel> vccBels, Set<Bel> gndBels, Collection<BelRoutethrough> routethroughs) {
+		// Create pseudo cells for the route-throughs and static source BELs
+		for (Bel bel : vccBels) {
+			// assuming LUT Bel
+			Cell cell = new Cell("Pseudo_" + bel.getSite().getName() + "_" + bel.getName(), libCells.get("LUT1"), true);
+			design.addCell(cell);
+			design.placeCell(cell, bel);
+		}
+
+		for (Bel bel : gndBels) {
+			// assuming LUT Bel
+			Cell cell = new Cell("Pseudo_" + bel.getSite().getName() + "_" + bel.getName(), libCells.get("LUT1"), true);
+			design.addCell(cell);
+			design.placeCell(cell, bel);
+		}
+
+		List<String> ffBels = new ArrayList<>(Arrays.asList("D5FF", "DFF", "C5FF", "CFF", "B5FF", "BFF", "A5FF", "AFF"));
+
+		for (BelRoutethrough belRoutethrough : routethroughs) {
+			Bel bel = belRoutethrough.getBel();
+			Site site = bel.getSite();
+
+			if (ffBels.contains(bel.getName())) {
+				Cell cell = new Cell("Pseudo_" + site.getName() + "_" + bel.getName(), libCells.get("FDRE"), true);
+				design.addCell(cell);
+
+				// Don't assign anything to the D, Q, or CE pins since they should be handled within the site.
+				// The CLK will come into the site at the clock pin. For routers to know to route to this pin, a
+				// pseudo cell pin must be added to the cell. Note: I cannot check the CLK site PIP to see if it is
+				// used and which nets are involved. Additionally, the RSCP does not report that the clk pin is used.
+				// So, am I forced to resort to assume VCC is coming into the CLK pin, and is then inverted at the
+				// SITE PIP, bringing GND to the FF BELs.
+				PseudoCellPin pseudoCK = new PseudoCellPin("pseudoCK", PinDirection.IN);
+				cell.attachPseudoPin(pseudoCK);
+				design.placeCell(cell, bel);
+				BelPin belPin = bel.getBelPin("CK");
+				pseudoCK.mapToBelPin(bel.getBelPin("CK"));
+				design.getVccNet().connectToPin(pseudoCK);
+
+				// Add a stand-in route-tree connecting the cell-pin sink and the sitepin.
+				String namePrefix = "intrasite:" + site.getType().name() + "/";
+				RouteTree routeTree = new RouteTree(site.getWire(namePrefix + "CLK.CLK"));
+				design.getVccNet().addSinkRouteTree(belPin, routeTree);
+
+			} else {
+				// assuming LUT Bel
+				Cell cell = new Cell("Pseudo_" + bel.getSite().getName() + "_" + bel.getName(), libCells.get("LUT1"), true);
+				design.addCell(cell);
+				design.placeCell(cell, bel);
+			}
+		}
+	}
+}

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoCheckpoint.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoCheckpoint.java
@@ -29,6 +29,7 @@ import edu.byu.ece.rapidSmith.design.subsite.*;
 import edu.byu.ece.rapidSmith.device.Bel;
 import edu.byu.ece.rapidSmith.device.BelPin;
 import edu.byu.ece.rapidSmith.device.Device;
+import edu.byu.ece.rapidSmith.device.PIP;
 
 /**
  * This class packages a TINCR checkpoint so that it can be returned to the user.
@@ -42,11 +43,13 @@ public final class VivadoCheckpoint {
 	private final Device device;
 	private final CellDesign design;
 	private final String partName;
-	private Set<Bel> routethroughBels;
-	private Collection<BelRoutethrough> routethroughObjects;
+	private Map<Bel, BelRoutethrough> belRoutethroughMap;
 	private Collection<Bel> vccSourceBels;
 	private Collection<Bel> gndSourceBels;
 	private Map<BelPin, CellPin> belPinToCellPinMap;
+
+	/** PIPs used by the static design */
+	private Collection<PIP> staticPips;
 
 	public VivadoCheckpoint(String partName, CellDesign design, Device device, CellLibrary libCells) {
 		this.partName = partName;
@@ -86,16 +89,19 @@ public final class VivadoCheckpoint {
 	}
 	
 	public void setRoutethroughBels(Map<Bel, BelRoutethrough> rtBels) {
-		this.routethroughBels = rtBels.keySet();
-		this.routethroughObjects = rtBels.values();
+		belRoutethroughMap = rtBels;
 	}
 	
 	public Collection<BelRoutethrough> getRoutethroughObjects() {
-		return routethroughObjects;
+		return belRoutethroughMap.values();
 	}
 	
 	public Set<Bel> getBelRoutethroughs() {
-		return routethroughBels;
+		return belRoutethroughMap.keySet();
+	}
+
+	public Map<Bel, BelRoutethrough> getBelRoutethroughMap() {
+		return belRoutethroughMap;
 	}
 
 	public Collection<Bel> getStaticSourceBels() {
@@ -127,5 +133,13 @@ public final class VivadoCheckpoint {
 	
 	public Map<BelPin, CellPin> getBelPinToCellPinMap() {
 		return this.belPinToCellPinMap;
+	}
+
+	public Collection<PIP> getStaticPips() {
+		return staticPips;
+	}
+
+	public void setStaticPips(Collection<PIP> staticPips) {
+		this.staticPips = staticPips;
 	}
 }

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/VivadoInterface.java
@@ -111,208 +111,37 @@ public final class VivadoInterface {
 		routingInterface.parseRoutingXDC(routingFile);
 		design.setPartPinMap(routingInterface.getPartPinMap());
 
-		VivadoCheckpoint vivadoCheckpoint = new VivadoCheckpoint(partName, design, device, libCells); 
-		
+		VivadoCheckpoint vivadoCheckpoint = new VivadoCheckpoint(partName, design, device, libCells);
+
+		PseudoCellHandler pseudoCellHandler = new PseudoCellHandler(design, device, libCells);
 		if (storeAdditionalInfo) {
+			Set<Bel> vccBels = routingInterface.getVccSourceBels();
+			Set<Bel> gndBels = routingInterface.getGndSourceBels();
 			vivadoCheckpoint.setRoutethroughBels(routingInterface.getRoutethroughsBels());
-			vivadoCheckpoint.setVccSourceBels(routingInterface.getVccSourceBels());
-			vivadoCheckpoint.setGndSourceBels(routingInterface.getGndSourceBels());
+			vivadoCheckpoint.setVccSourceBels(vccBels);
+			vivadoCheckpoint.setGndSourceBels(gndBels);
 			vivadoCheckpoint.setBelPinToCellPinMap(placementInterface.getPinMap());
-			addPseudoCells(vivadoCheckpoint);
+			pseudoCellHandler.addPseudoCells(vccBels, gndBels, vivadoCheckpoint.getRoutethroughObjects());
 		}
 
 		if (addPseudoVccPins) {
 			// Detect and add pseudo VCC pins based off of the placement.
-			addPseudoVccPins(vivadoCheckpoint);
+			pseudoCellHandler.addPseudoVccPins();
 		}
 
 		// Mark the used static resources
 		if (mode == ImplementationMode.RECONFIG_MODULE) {
 			String resourcesFile = rscpPath.resolve("static.rsc").toString();
-			StaticResourcesInterface staticInterface = new StaticResourcesInterface(design, device);
+			StaticResourcesInterface staticInterface = new StaticResourcesInterface(design, device, routingInterface.getRoutethroughsBels());
 			staticInterface.parseResourcesRSC(resourcesFile);
 			design.setRmStaticNetMap(staticInterface.getRmStaticNetMap());
 			design.setStaticRouteStringMap(staticInterface.getStaticRouteStringMap());
+			vivadoCheckpoint.setStaticPips(staticInterface.getStaticPips());
+			vivadoCheckpoint.setRoutethroughBels(staticInterface.getBelRoutethroughMap());
 		}
-		
+
+
 		return vivadoCheckpoint;
-	}
-
-	/**
-	 * Adds pseudo cells to the design for route-through LUTs, implied latches, and static source LUTs.
-	 * @param vivadoCheckpoint the vivado checkpoint containing the device, design, and cell library.
-	 */
-	private static void addPseudoCells(VivadoCheckpoint vivadoCheckpoint) {
-		CellDesign design = vivadoCheckpoint.getDesign();
-		CellLibrary libCells = vivadoCheckpoint.getLibCells();
-		// Create pseudo cells for the routethroughs and static source BELs
-		for (Bel bel : vivadoCheckpoint.getVccSourceBels()) {
-			// assuming LUT Bel
-			Cell cell = new Cell("Pseudo_" + bel.getSite().getName() + "_" + bel.getName(), libCells.get("LUT1"), true);
-			design.addCell(cell);
-			design.placeCell(cell, bel);
-		}
-
-		for (Bel bel : vivadoCheckpoint.getGndSourceBels()) {
-			// assuming LUT Bel
-			Cell cell = new Cell("Pseudo_" + bel.getSite().getName() + "_" + bel.getName(), libCells.get("LUT1"), true);
-			design.addCell(cell);
-			design.placeCell(cell, bel);
-		}
-
-		List<String> ffBels = new ArrayList<>(Arrays.asList("D5FF", "DFF", "C5FF", "CFF", "B5FF", "BFF", "A5FF", "AFF"));
-
-		for (BelRoutethrough belRoutethrough : vivadoCheckpoint.getRoutethroughObjects()) {
-			Bel bel = belRoutethrough.getBel();
-			Site site = bel.getSite();
-
-			if (ffBels.contains(bel.getName())) {
-				Cell cell = new Cell("Pseudo_" + site.getName() + "_" + bel.getName(), libCells.get("FDRE"), true);
-				design.addCell(cell);
-
-				// Don't assign anything to the D, Q, or CE pins since they should be handled within the site.
-				// The CLK will come into the site at the clock pin. For routers to know to route to this pin, a
-				// pseudo cell pin must be added to the cell. Note: I cannot check the CLK site PIP to see if it is
-				// used and which nets are involved. Additionally, the RSCP does not report that the clk pin is used.
-				// So, am I forced to resort to assume VCC is coming into the CLK pin, and is then inverted at the
-				// SITE PIP, bringing GND to the FF BELs.
-				PseudoCellPin pseudoCK = new PseudoCellPin("pseudoCK", PinDirection.IN);
-				cell.attachPseudoPin(pseudoCK);
-				design.placeCell(cell, bel);
-				BelPin belPin = bel.getBelPin("CK");
-				pseudoCK.mapToBelPin(bel.getBelPin("CK"));
-				design.getVccNet().connectToPin(pseudoCK);
-
-				// Add a stand-in route-tree connecting the cell-pin sink and the sitepin.
-				String namePrefix = "intrasite:" + site.getType().name() + "/";
-				RouteTree routeTree = new RouteTree(site.getWire(namePrefix + "CLK.CLK"));
-				design.getVccNet().addSinkRouteTree(belPin, routeTree);
-
-			} else {
-				// assuming LUT Bel
-				Cell cell = new Cell("Pseudo_" + bel.getSite().getName() + "_" + bel.getName(), libCells.get("LUT1"), true);
-				design.addCell(cell);
-				design.placeCell(cell, bel);
-			}
-		}
-	}
-
-	/**
-	 * Creates a route tree, starting from an input site pin and ending at a BelPin.
-	 * Used for pseudo VCC pins.
-	 * @param net the vcc net
-	 * @param sinkPin
-	 */
-	private static void createPseudoVccSinkTree(CellNet net, BelPin sinkPin) {
-		// The BelPin must be a sink Lut BEL Pin
-		Wire lutPinWire = sinkPin.getWire().getReverseWireConnections().iterator().next().getSinkWire();
-		SitePin sitePin = lutPinWire.getReverseConnectedPin();
-		RouteTree rt = new RouteTree(sitePin.getInternalWire());
-		rt.connect(lutPinWire.getWireConnections().iterator().next());
-		net.addSinkRouteTree(sitePin, rt);
-		net.addSinkRouteTree(sinkPin, rt);
-	}
-
-	/**
-	 * Searches the design and adds pseudo cell pins for physical-only vcc routes that need to be made.
-	 * @param vivadoCheckpoint the Vivado checkpoint containing the device and design
-	 */
-	private static void addPseudoVccPins(VivadoCheckpoint vivadoCheckpoint) {
-		CellDesign design = vivadoCheckpoint.getDesign();
-		CellNet vccNet = design.getVccNet();
-
-		// If a 5LUT Bel and a 6LUT Bel are both used, we must tie A6 to VCC
-		// Get ALL used LUT bels (including bels with no logical counterpart)
-		Collection<Bel> usedLut6Bels = design.getUsedBels().stream()
-				.filter(bel -> bel.getName().matches("[A-D]6LUT")).collect(Collectors.toList());
-		Collection<Bel> usedLut5Bels = design.getUsedBels().stream()
-				.filter(bel -> bel.getName().matches("[A-D]5LUT")).collect(Collectors.toList());
-
-		for (Bel bel : usedLut6Bels) {
-			Cell cell = design.getCellAtBel(bel);
-			assert (cell != null);
-
-			switch (cell.getType()) {
-				case "SRLC32E":
-					CellPin pin = cell.attachPseudoPin("pseudoA1", PinDirection.IN);
-					BelPin belPin = bel.getBelPin("A1");
-					pin.mapToBelPin(belPin);
-					vccNet.connectToPin(pin);
-					createPseudoVccSinkTree(vccNet, belPin);
-					break;
-				case "SRLC16E":
-				case "SRL16E":
-					CellPin a1pin = cell.attachPseudoPin("pseudoA1", PinDirection.IN);
-					belPin = bel.getBelPin("A1");
-					a1pin.mapToBelPin(belPin);
-					vccNet.connectToPin(a1pin);
-					createPseudoVccSinkTree(vccNet, belPin);
-
-					CellPin a6pin = cell.attachPseudoPin("pseudoA6", PinDirection.IN);
-					belPin = bel.getBelPin("A6");
-					a6pin.mapToBelPin(belPin);
-					vccNet.connectToPin(a6pin);
-					createPseudoVccSinkTree(vccNet, belPin);
-					break;
-				case "RAMS32":
-				case "RAMD32":
-					CellPin wa6pin = cell.attachPseudoPin("pseudoWA6", PinDirection.IN);
-					belPin = bel.getBelPin("WA6");
-					wa6pin.mapToBelPin(belPin);
-					vccNet.connectToPin(wa6pin);
-					createPseudoVccSinkTree(vccNet, belPin);
-
-					a6pin = cell.attachPseudoPin("pseudoA6", PinDirection.IN);
-					belPin = bel.getBelPin("A6");
-					a6pin.mapToBelPin(belPin);
-					vccNet.connectToPin(a6pin);
-					createPseudoVccSinkTree(vccNet, belPin);
-					break;
-				default:
-					break;
-			}
-		}
-
-		for (Bel bel : usedLut5Bels) {
-			Cell cell = design.getCellAtBel(bel);
-			assert (cell != null);
-
-			// Check to see if both the LUT6 and LUT5 BEL are used
-			Bel lut6Bel = bel.getSite().getBel(bel.getName().charAt(0) + "6LUT");
-			Cell lut6Cell = design.getCellAtBel(lut6Bel);
-			if (usedLut6Bels.contains(lut6Bel)) {
-				BelPin belPin = lut6Bel.getBelPin("A6");
-
-				boolean macroPseudoPin = false;
-				// Pseudo pins may have already been created for macro cells
-				// TODO: Get rid of this duplication of efforts.
-				for (CellPin pseudoPin : lut6Cell.getPseudoPins()) {
-					if (pseudoPin.getMappedBelPin().equals(belPin))
-						macroPseudoPin = true;
-				}
-
-				if (!macroPseudoPin) {
-					CellPin pin = lut6Cell.attachPseudoPin("pseudoA6", PinDirection.IN);
-
-					// Assume that vcc can be routed to this pin.
-					pin.mapToBelPin(belPin);
-					vccNet.connectToPin(pin);
-					createPseudoVccSinkTree(vccNet, belPin);
-				}
-			}
-
-			if (cell.getType().equals("SRLC16E") || cell.getType().equals("SRL16E")) {
-				CellPin pin = cell.attachPseudoPin("pseudoA1", PinDirection.IN);
-				BelPin belPin = bel.getBelPin("A1");
-				pin.mapToBelPin(belPin);
-				vccNet.connectToPin(pin);
-				createPseudoVccSinkTree(vccNet, belPin);
-			}
-
-		}
-
-		// We have added pins, so we need to recalculate the route status
-		vccNet.computeRouteStatus();
 	}
 
 
@@ -326,19 +155,6 @@ public final class VivadoInterface {
 		for (Cell staticSource : design.getCells().stream()
 				.filter(Cell::isLut)
 				.filter(c -> c.getPin("O").getNet() != null && c.getPin("O").getNet().isStaticNet())
-				.collect(Collectors.toList())) {
-			design.removeCell(staticSource);
-		}
-	}
-
-	/**
-	 * Removes pseudo lut cells from the design. Pseudo cells are only used when pseudo pins are needed for
-	 * physical routing.
-	 * @param design the design
-	 */
-	private static void removePseudoLuts(CellDesign design) {
-		for (Cell staticSource : design.getCells().stream()
-				.filter(Cell::isPseudo)
 				.collect(Collectors.toList())) {
 			design.removeCell(staticSource);
 		}
@@ -366,7 +182,8 @@ public final class VivadoInterface {
 	public static void writeTCP(String tcpDirectory, CellDesign design, Device device, CellLibrary libCells, boolean intrasiteRouting) throws IOException {
 		new File(tcpDirectory).mkdir();
 
-		removePseudoLuts(design);
+		PseudoCellHandler pseudoCellHandler = new PseudoCellHandler(design, device, libCells);
+		pseudoCellHandler.removePseudoLuts();
 
 		// Remove static-source LUTs
 		removeStaticSourceLUTs(design);

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcPlacementInterface.java
@@ -214,26 +214,6 @@ public class XdcPlacementInterface extends AbstractXdcInterface {
 	}
 
 	/**
-	 * Tries to retrieve a BelPin object from the currently loaded device
-	 * If the pin does not exist, a ParseException is thrown.
-	 * 
-	 * @param bel Bel which the pin is attached
-	 * @param pinName Name of the bel pin
-	 * @return BelPin
-	 */
-	private BelPin tryGetBelPin(Bel bel, String pinName) {
-		
-		BelPin pin = bel.getBelPin(pinName);
-		
-		if (pin == null) {
-			throw new ParseException(String.format("BelPin: \"%s/%s\" does not exist in the current device.\n"
-												 + "On line %d of %s", bel.getName(), pinName, currentLineNumber, currentFile));
-		}
-		
-		return pin;
-	}
-		
-	/**
 	 * Creates a placement.xdc file from the cells of the given design 
 	 * This file can be imported into Vivado to constrain the cells to a physical location
 	 * 
@@ -291,7 +271,7 @@ public class XdcPlacementInterface extends AbstractXdcInterface {
 			}
 			// If OOC mode, write the partition pin location properties.
 			// This tells Vivado the tile where the Partition Pin should be placed (but not the exact wire).
-			// Note that there is a “bug” where Vivado won't let you set the ROUTE string for nets where the source is
+			// Note that there is a "bug" where Vivado won't let you set the ROUTE string for nets where the source is
 			// a port (or partition pin). So, Vivado has to route these nets ultimately.
 			if (design.getImplementationMode() == ImplementationMode.OUT_OF_CONTEXT)
 			{

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/vivado/XdcRoutingInterface.java
@@ -51,7 +51,6 @@ public class XdcRoutingInterface extends AbstractXdcInterface {
 	private int currentLineNumber;
 	private String currentFile;
 	private Map<Bel, BelRoutethrough> belRoutethroughMap;
-	private Pattern pipNamePattern;
 	/** Map of partition pins (ooc ports) to their ooc tile and node **/
 	private Map<String, String> partPinMap;
 	private ImplementationMode implementationMode;
@@ -77,7 +76,6 @@ public class XdcRoutingInterface extends AbstractXdcInterface {
 		this.staticSourceMap = new HashMap<>();
 		this.belPinToCellPinMap = pinMap;
 		this.currentLineNumber = 0;
-		this.pipNamePattern = Pattern.compile("(.*)/.*\\.([^<]*)((?:<<)?->>?)(.*)"); 
 		this.implementationMode = design.getImplementationMode();
 		this.libCells = libCells;
 
@@ -203,7 +201,6 @@ public class XdcRoutingInterface extends AbstractXdcInterface {
 	 * where space separated elements are different elements in the array
 	 */
 	private void processSitePips (String[] toks) {
-		
 		Site site = tryGetSite(toks[1]);
 		readUsedSitePips(site, toks);
 		createStaticSubsiteRouteTrees(site);
@@ -227,7 +224,7 @@ public class XdcRoutingInterface extends AbstractXdcInterface {
 			
 			Site site = tryGetSite(sitePinToks[0]);
 			SitePin pin = tryGetSitePin(site, sitePinToks[1]);
-			
+
 			if (pin.isInput()) { // of a site
 				createIntrasiteRoute(pin, net, design.getUsedSitePipsAtSite(site));
 			}
@@ -509,7 +506,6 @@ public class XdcRoutingInterface extends AbstractXdcInterface {
 	 * {@code LUT_RTS site0/bel0/inputPin0/outputPin0 site1/bel1/inputPin1/outputPin1 ...}
 	 */
 	private void processLutRoutethroughs(String[] toks) {
-
 		this.belRoutethroughMap = new HashMap<>();
 		
 		for (int i = 1; i < toks.length; i++) {
@@ -763,9 +759,7 @@ public class XdcRoutingInterface extends AbstractXdcInterface {
 	 * {@code SITE_PIPS siteName pip0:input0 pip1:input1 ... pipN:inputN}
 	 */
 	private void readUsedSitePips(Site site, String[] toks) {
-
 		HashSet<Integer> usedSitePips = new HashSet<>();
-
 		String namePrefix = "intrasite:" + site.getType().name() + "/";
 
 		//create hashmap that shows pip used to input val
@@ -1142,24 +1136,6 @@ public class XdcRoutingInterface extends AbstractXdcInterface {
 									+ "On line " + this.currentLineNumber + " of " + currentFile);
 		}
 		return source;
-	}
-
-	/**
-	 * Tries to retrieve a BelPin object from the currently loaded device <br>
-	 * If the pin does not exist, a ParseException is thrown. <br>
-	 * 
-	 * @param bel Bel which the pin is attached
-	 * @param pinName Name of the bel pin
-	 * @return BelPin
-	 */
-	private BelPin tryGetBelPin(Bel bel, String pinName) {
-		BelPin pin = bel.getBelPin(pinName);
-		
-		if (pin == null) {
-			throw new ParseException(String.format("BelPin: \"%s/%s\" does not exist in the current device"
-												 + "On line %d of %s", bel.getName(), pinName, currentLineNumber, currentFile));
-		}
-		return pin;
 	}
 	
 	/**

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/xray/FasmBelInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/xray/FasmBelInterface.java
@@ -205,6 +205,11 @@ public class FasmBelInterface extends AbstractFasmInterface{
         }
         Cell lutCell = design.getCellAtBel(lutBel);
 
+        if (lutCell != null && vccSourceBels.contains(lutBel)) {
+            System.err.println("ERROR: VCC LUT still has a cell: " + lutCell.getName());
+            return;
+        }
+
         // Get the properly formatted physical LUT Equation
         LutEquation lutEquation = getLutEquation(lutBel);
 
@@ -344,7 +349,7 @@ public class FasmBelInterface extends AbstractFasmInterface{
                 break;
             default:
                 System.err.println("WARNING: Unrecognized FF/Latch Cell Type for cell " + cell.getName() + ":"
-                        + cell.getType() + ". No FASM isntructions will be printed for the cell.");
+                        + cell.getType() + ". No FASM instructions will be printed for the cell.");
                 break;
         }
 
@@ -357,6 +362,35 @@ public class FasmBelInterface extends AbstractFasmInterface{
     }
 
     /* LUT RAMs (Distributed RAMs) */
+
+	private void printRam32Init(Bel bel, String fullBelName) throws IOException {
+		Cell cell = design.getCellAtBel(bel);
+		assert (cell.isInternal());
+		String internalCellName = cell.getName().substring(cell.getName().lastIndexOf('/') + 1);
+		Cell parentCell = cell.getParent();
+
+		// TODO: Don't assume String INIT or that the property is in HEX.
+		String ramInit = parentCell.getProperties().get("INIT").getStringValue();
+
+		// Remove the leading 'h
+		ramInit = ramInit.substring(ramInit.lastIndexOf("h") + 1);
+
+		// Switch on the LUT RAM Macro type
+		switch (parentCell.getType()) {
+			case "RAM32X1S":
+				// Just contains a single RAMS32 (SP)
+				assert (internalCellName.equals("SP"));
+				// The cell should be on a LUT6 BEL, so we set only the top 32 bits.
+				printLutInitString(hexToBinaryInitString(ramInit), fullBelName, true);
+				break;
+			default:
+				System.err.println("WARNING: Unexpected macro type for LUT RAM macro " + parentCell.getName() + ": "
+						+ parentCell.getType() + ". " + "No LUT RAM INIT instruction will be written for "
+						+ cell.getName() + ".");
+				break;
+		}
+	}
+
 
     /**
      * Prints the INIT property for a 64-LUTRAM. Only RAMD64E tested.
@@ -433,9 +467,9 @@ public class FasmBelInterface extends AbstractFasmInterface{
                 // QUESTION: Is it safe to assume a MEM5 will always be paired with a MEM6? (probably not)
                 if (bel.getType().equals("LUT_OR_MEM5"))
                     break;
-
                 fileout.write(fullBelName + "RAM 1\n");
                 fileout.write(fullBelName + "SMALL 1\n");
+				printRam32Init(bel, fullBelName);
                 break;
             case "RAMD64E":
                 assert (bel.getType().equals("LUT_OR_MEM6"));

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/xray/FasmRoutingInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/xray/FasmRoutingInterface.java
@@ -64,7 +64,8 @@ public class FasmRoutingInterface extends AbstractFasmInterface {
 					// HCLK buffer should still be enabled, even though the net is terminating on a LUT that drives
 					// nothing else.
 					if ((net.isClkNet() || net.isPartPinCLKNet())
-							&& (tileType.equals(hclkR) || tileType.equals(hclkL))) {
+							&& (tileType.equals(hclkR) || tileType.equals(hclkL))
+							&& source.getName().contains("HCLK_CK_BUFHCLK")) {
 						// Add the HCLK Enable Buffer wires to a set to avoid writing their instructions multiple times
 						hclkBufferEnableWires.add(source);
 					}

--- a/src/main/java/edu/byu/ece/rapidSmith/interfaces/xray/XrayInterface.java
+++ b/src/main/java/edu/byu/ece/rapidSmith/interfaces/xray/XrayInterface.java
@@ -3,15 +3,16 @@ package edu.byu.ece.rapidSmith.interfaces.xray;
 import edu.byu.ece.rapidSmith.design.subsite.BelRoutethrough;
 import edu.byu.ece.rapidSmith.design.subsite.CellDesign;
 import edu.byu.ece.rapidSmith.design.subsite.ImplementationMode;
-import edu.byu.ece.rapidSmith.design.subsite.RouteStringTree;
 import edu.byu.ece.rapidSmith.device.Bel;
 import edu.byu.ece.rapidSmith.device.Device;
+import edu.byu.ece.rapidSmith.device.PIP;
 import edu.byu.ece.rapidSmith.device.Site;
 import edu.byu.ece.rapidSmith.util.Exceptions;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,15 +36,15 @@ public final class XrayInterface {
 	private final Device device;
 	private final Set<Bel> gndSourceBels;
 	private final Set<Bel> vccSourceBels;
-	private final Map<String, RouteStringTree> staticRouteStringMap;
+	private final Collection<PIP> staticPips;
 
-	public XrayInterface(CellDesign design, Device device, Map<Bel, BelRoutethrough> belRoutethroughMap, Set<Bel> vccSourceBels, Set<Bel> gndSourceBels, Map<String, RouteStringTree> staticRouteStringMap) {
+	public XrayInterface(CellDesign design, Device device, Map<Bel, BelRoutethrough> belRoutethroughMap, Set<Bel> vccSourceBels, Set<Bel> gndSourceBels, Collection<PIP> staticPips) {
 		this.design = design;
 		this.device = device;
 		this.belRoutethroughMap = belRoutethroughMap;
 		this.gndSourceBels = gndSourceBels;
 		this.vccSourceBels = vccSourceBels;
-		this.staticRouteStringMap = staticRouteStringMap;
+		this.staticPips = staticPips;
 	}
 
 	/**
@@ -61,7 +62,7 @@ public final class XrayInterface {
 		BufferedWriter fileout = new BufferedWriter(new FileWriter(fasmPath));
 
 		// Write the static resources
-		FasmStaticInterface fasmStaticInterface = new FasmStaticInterface(device, design, fileout);
+		FasmStaticInterface fasmStaticInterface = new FasmStaticInterface(device, design, staticPips, fileout);
 		fasmStaticInterface.writeStaticDesignPips();
 
 		// Write properties for all used logic BELs


### PR DESCRIPTION
This PR contains several changes that were made to make routing (with RSVRoute) and Maverick easier. Many of the changes are very small, but there are two I'll highlight here:

- StaticResourcesInterface: Revamped the used site route-throughs import process to process not just the reserved sites, but also the internal details of the site route-throughs (LUT route-throughs and site PIPs).

- Added a pseudo cell handler to the Vivado Interface package. This class contains methods to add pseudo vcc pins that are implied by certain placement situations. Additionally, this class contains methods that create pseudo cells for all route-throughs, VCC source LUTs, and GND source LUTs; these are necessary because a LUT6 BEL can be used as a route-through and the corresponding LUT5 BEL can be used as a static source; this case requires a pseudo VCC pin, but a pseudo pin needs a cell to attach to. There is some duplication of efforts going on here since the code that was handling LUT route-throughs and static source LUTs has not been removed. Once this PR is merged, I'll make an issue about this. 

I am making this PR in preparation for the Maverick repo.